### PR TITLE
fix: do not add CORS Credentials header

### DIFF
--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -62,7 +62,6 @@ export default async function createDaemon (opts) {
 
   await ipfsd.api.config.set('API.HTTPHeaders.Access-Control-Allow-Origin', origins)
   await ipfsd.api.config.set('API.HTTPHeaders.Access-Control-Allow-Method', ['PUT', 'GET', 'POST'])
-  await ipfsd.api.config.set('API.HTTPHeaders.Access-Control-Allow-Credentials', ['true'])
 
   return ipfsd
 }


### PR DESCRIPTION
AFAIK IPFS Desktop does not need this header.

See also:

- Potential problem with  `Access-Control-Allow-Credentials`: https://github.com/ipfs/go-ipfs/issues/5745
- HTTP Headers Cleanup: https://github.com/ipfs/in-web-browsers/issues/132
