### PR TITLE
feat: automatically migrate repository (fixes #687)

### DIFF
--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -9,6 +9,10 @@ export default async function createDaemon (opts) {
   opts.flags = opts.flags || []
   opts.keysize = opts.keysize || 4096
 
+  if (!opts.flags.includes('--migrate=true')) {
+    opts.flags = [...opts.flags, '--migrate=true']
+  }
+
   if (opts.type !== 'go') {
     throw new Error(`${opts.type} connection is not supported yet`)
   }

--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -6,12 +6,8 @@ import logger from './logger'
 export default async function createDaemon (opts) {
   opts.type = opts.type || 'go'
   opts.path = opts.path || ''
-  opts.flags = opts.flags || []
+  opts.flags = opts.flags || ['--migrate=true', '--routing=dhtclient']
   opts.keysize = opts.keysize || 4096
-
-  if (!opts.flags.includes('--migrate=true')) {
-    opts.flags = [...opts.flags, '--migrate=true']
-  }
 
   if (opts.type !== 'go') {
     throw new Error(`${opts.type} connection is not supported yet`)


### PR DESCRIPTION
Adds flag `--migrate=true` to migrate the repo automatically to the newest version.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>