### PR TITLE
feat: handle errors better

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,20 @@ if (!app.requestSingleInstanceLock()) {
   process.exit(1)
 }
 
+const issueTemplate = (e) => `Please describe what you were doing when this error happened.
+
+**Specifications**
+
+- **OS**: ${process.platform}
+- **IPFS Desktop Version**: ${app.getVersion()}
+
+**Error**
+
+\`\`\`
+${e.stack}
+\`\`\`
+`
+
 function handleError (e) {
   dialog.showMessageBox({
     type: 'error',
@@ -30,8 +44,7 @@ function handleError (e) {
       const path = app.getPath('userData')
       shell.openItem(path)
     } else if (option === 2) {
-      let text = 'Please describe what you were doing when this error happened.\n\n```\n' + e.stack + '\n```'
-      shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=' + encodeURI(text))
+      shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=${encodeURI(issueTemplate(e))}`)
     }
 
     process.exit(1)

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ const issueTemplate = (e) => `Please describe what you were doing when this erro
 
 - **OS**: ${process.platform}
 - **IPFS Desktop Version**: ${app.getVersion()}
+- **Electron Version**: ${process.versions.electron}
+- **Chrome Version**: ${process.versions.chrome}
 
 **Error**
 
@@ -30,25 +32,25 @@ ${e.stack}
 `
 
 function handleError (e) {
-  dialog.showMessageBox({
+  const option = dialog.showMessageBox({
     type: 'error',
-    title: 'Something unexpected happened :-(',
-    message: e.stack + '\nPlease choose one of the options bellow. All of them will copy the error message to the clipboard.',
+    title: 'IPFS Desktop has shutdown',
+    message: 'IPFS Desktop has shutdown because of an error. You can restart the app or report the error to the developers, which requires a GitHub account.',
     buttons: [
       'Close',
-      'Open logs',
-      'Create a new issue'
-    ]
-  }, option => {
-    if (option === 1) {
-      const path = app.getPath('userData')
-      shell.openItem(path)
-    } else if (option === 2) {
-      shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=${encodeURI(issueTemplate(e))}`)
-    }
-
-    process.exit(1)
+      'Report the error to the developers',
+      'Restart the app'
+    ],
+    cancelId: 0
   })
+
+  if (option === 1) {
+    shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=${encodeURI(issueTemplate(e))}`)
+  } else if (option === 2) {
+    app.relaunch()
+  }
+
+  app.exit(1)
 }
 
 async function setupConnection () {
@@ -71,7 +73,7 @@ async function run () {
     await app.whenReady()
   } catch (e) {
     dialog.showErrorBox('Electron could not start', e.stack)
-    process.exit(1)
+    app.exit(1)
   }
 
   try {


### PR DESCRIPTION
If an error occurs while Electron is getting ready, we just show up a dialog telling that. There isn't much we can do. On the other hand, if the error happens during the execution of IPFS Desktop itself, we will have this error message:

![image](https://user-images.githubusercontent.com/5447088/48705817-3181c000-ebf2-11e8-87dd-afe4069880c1.png)

The first option clearly opens the logs directory. The second option opens an URL to an issue pre-filled with the details of the error, like this:

![image](https://user-images.githubusercontent.com/5447088/48705856-4eb68e80-ebf2-11e8-8db8-5d7148810fd1.png)

This was something we didn't have in the last version, but we need to improve a lot: error handling! This will catch any major errors that might not be caught in other parts of the app.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>