### PR TITLE
fix: Web UI language matches menubar

### DIFF
--- a/src/hooks/webui/index.js
+++ b/src/hooks/webui/index.js
@@ -1,6 +1,6 @@
 import { logo, logger, store } from '../../utils'
 import { join } from 'path'
-import { screen, BrowserWindow, ipcMain } from 'electron'
+import { screen, BrowserWindow, ipcMain, app } from 'electron'
 import serve from 'electron-serve'
 
 serve({ scheme: 'webui', directory: `${__dirname}/app` })
@@ -62,6 +62,6 @@ export default async function (ctx) {
       resolve()
     })
 
-    window.loadURL(`webui://-?api=${apiAddress}#/`)
+    window.loadURL(`webui://-?api=${apiAddress}&lng=${app.getLocale()}#/`)
   })
 }


### PR DESCRIPTION
This should fix the issue where the Web UI language wouldn't match menubar's. @lidel could you take a look to see if it works on your end?

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>