### PR TITLE
fix: no error when API.HTTPHeaders is empty

### DIFF
--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -56,7 +56,13 @@ export default async function createDaemon (opts) {
     })
   }
 
-  let origins = await ipfsd.api.config.get('API.HTTPHeaders.Access-Control-Allow-Origin') || []
+  let origins = []
+  try {
+    origins = await ipfsd.api.config.get('API.HTTPHeaders.Access-Control-Allow-Origin')
+  } catch (e) {
+    logger.warn(e)
+  }
+
   if (!origins.includes('webui://-')) origins.push('webui://-')
   if (!origins.includes('https://webui.ipfs.io')) origins.push('https://webui.ipfs.io')
 


### PR DESCRIPTION
This fixes an issue when the `API.HTTPHeaders` key is empty on the IFPS configuration. When that happens, we just assume the array of origins is an empty array.

fixes #676.

/cc @NatoBoram

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>