### PR TITLE
fix: do not cleanup api and repo.lock files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,17 +55,23 @@ function handleError (e) {
 
 async function setupConnection () {
   let config = store.get('config')
+  let updateCfg = false
 
   if (config === null) {
-    config = {
-      type: 'go',
-      path: join(app.getPath('home'), '.ipfs')
-    }
+    config = { type: 'go' }
+    updateCfg = true
+  }
 
+  const ipfsd = await createDaemon(config)
+
+  // createDaemon has changed the config object,
+  // but didn't add the repo variable.
+  if (updateCfg) {
+    config.path = ipfsd.repoPath
     store.set('config', config)
   }
 
-  return createDaemon(config)
+  return ipfsd
 }
 
 async function run () {

--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -1,5 +1,4 @@
 import IPFSFactory from 'ipfsd-ctl'
-import fs from 'fs-extra'
 
 export default async function createDaemon (opts) {
   opts.type = opts.type || 'go'
@@ -11,7 +10,6 @@ export default async function createDaemon (opts) {
     throw new Error(`${opts.type} connection is not supported yet`)
   }
 
-  const init = !(await fs.pathExists(opts.path)) || fs.readdirSync(opts.path).length === 0
   const factory = IPFSFactory.create({ type: opts.type })
 
   const ipfsd = await new Promise((resolve, reject) => {
@@ -21,7 +19,7 @@ export default async function createDaemon (opts) {
       repoPath: opts.path
     }, (e, ipfsd) => {
       if (e) return reject(e)
-      if (ipfsd.initialized || !init) {
+      if (ipfsd.initialized) {
         return resolve(ipfsd)
       }
 


### PR DESCRIPTION
Previously we were cleaning up the `api` and `repo.lock` files because the shutdown on Windows was not working correctly on the IPFS daemon. It seems the issue was already resolved (see https://github.com/ipfs/go-ipfs/issues/3061).

This PR removes that code and this should also fix #689 and fix #688.

@lidel can you check this out, please?