### PR TITLE
fix: a typo in CORS header name

### DIFF
--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -61,7 +61,7 @@ export default async function createDaemon (opts) {
   if (!origins.includes('https://webui.ipfs.io')) origins.push('https://webui.ipfs.io')
 
   await ipfsd.api.config.set('API.HTTPHeaders.Access-Control-Allow-Origin', origins)
-  await ipfsd.api.config.set('API.HTTPHeaders.Access-Control-Allow-Method', ['PUT', 'GET', 'POST'])
+  await ipfsd.api.config.set('API.HTTPHeaders.Access-Control-Allow-Methods', ['PUT', 'GET', 'POST'])
 
   return ipfsd
 }


### PR DESCRIPTION
`Access-Control-Allow-Method` was missing `s` :)

![2018-11-24--15-19-22](https://user-images.githubusercontent.com/157609/48969265-c45c9900-effc-11e8-9bc2-9405db96f312.png)
