### PR TITLE
feat: open urls on default browser

### DIFF
--- a/src/hooks/webui/preload.js
+++ b/src/hooks/webui/preload.js
@@ -1,4 +1,11 @@
-const { ipcRenderer } = require('electron')
+const { ipcRenderer, shell } = require('electron')
+
+document.addEventListener('click', function (event) {
+  if (event.target.tagName === 'A' && event.target.href.startsWith('http')) {
+    event.preventDefault()
+    shell.openExternal(event.target.href)
+  }
+})
 
 ipcRenderer.on('updatedPage', (_, url) => {
   window.location.hash = url


### PR DESCRIPTION
Open `http`/`https` links on default browser. I think it is safe to assume that all links we want to open in the default browser start with `http`. There aren't any other URL kinds on Web UI.

closes #720 

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>