### PR TITLE
fix: close web ui on app.quit()

### DIFF
--- a/src/hooks/webui/index.js
+++ b/src/hooks/webui/index.js
@@ -46,7 +46,7 @@ export default async function (ctx) {
     window.focus()
   })
 
-  ipcMain.on('app.quit', () => {
+  app.on('before-quit', () => {
     // Makes sure the app quits even though we prevent
     // the closing of this window.
     window.destroy()


### PR DESCRIPTION
Use `before-quit` event from Electron instead of custom event. Probably this will fix the issue on #730 where `app.stop` is called but the app doesn't quit.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>