### PR TITLE
feat: improve security of electron app

### DIFF
--- a/src/hooks/app-events.js
+++ b/src/hooks/app-events.js
@@ -1,0 +1,19 @@
+import { app, shell } from 'electron'
+
+export default function () {
+  app.on('web-contents-created', (_, contents) => {
+    contents.on('will-navigate', (event, url) => {
+      const parsedUrl = new URL(url)
+
+      if (parsedUrl.origin !== 'webui://-') {
+        event.preventDefault()
+        shell.openExternal(url)
+      }
+    })
+
+    contents.on('new-window', (event, url) => {
+      event.preventDefault()
+      shell.openExternal(url)
+    })
+  })
+}

--- a/src/hooks/app-events.js
+++ b/src/hooks/app-events.js
@@ -21,7 +21,7 @@ export default function () {
     callback({ // eslint-disable-line
       responseHeaders: {
         ...details.responseHeaders,
-        'Content-Security-Policy': ['default-src \'none\'']
+        'Content-Security-Policy': ["default-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"]
       }
     })
   })

--- a/src/hooks/app-events.js
+++ b/src/hooks/app-events.js
@@ -1,4 +1,4 @@
-import { app, shell, session } from 'electron'
+import { app, shell } from 'electron'
 
 export default function () {
   app.on('web-contents-created', (_, contents) => {
@@ -14,15 +14,6 @@ export default function () {
     contents.on('new-window', (event, url) => {
       event.preventDefault()
       shell.openExternal(url)
-    })
-  })
-
-  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-    callback({ // eslint-disable-line
-      responseHeaders: {
-        ...details.responseHeaders,
-        'Content-Security-Policy': ["default-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"]
-      }
     })
   })
 }

--- a/src/hooks/app-events.js
+++ b/src/hooks/app-events.js
@@ -1,4 +1,4 @@
-import { app, shell } from 'electron'
+import { app, shell, session } from 'electron'
 
 export default function () {
   app.on('web-contents-created', (_, contents) => {
@@ -14,6 +14,15 @@ export default function () {
     contents.on('new-window', (event, url) => {
       event.preventDefault()
       shell.openExternal(url)
+    })
+  })
+
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({ // eslint-disable-line
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': ['default-src \'none\'']
+      }
     })
   })
 }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+import appEvents from './app-events'
 import autoLaunch from './auto-launch'
 import downloadHash from './download-hash'
 import ipfs from './ipfs'
@@ -6,6 +7,7 @@ import openDataFolder from './open-data-folder'
 import takeScreenshot from './take-screenshot'
 
 export default async function (ctx) {
+  await appEvents(ctx)
   await webui(ctx)
   await autoLaunch(ctx)
   await downloadHash(ctx)

--- a/src/hooks/webui/index.js
+++ b/src/hooks/webui/index.js
@@ -17,7 +17,8 @@ const createWindow = () => {
     height: store.get('window.height', dimensions.height < 900 ? dimensions.height : 900),
     webPreferences: {
       preload: join(__dirname, 'preload.js'),
-      webSecurity: false
+      webSecurity: false,
+      allowRunningInsecureContent: false
     }
   })
 

--- a/src/hooks/webui/preload.js
+++ b/src/hooks/webui/preload.js
@@ -1,11 +1,4 @@
-const { ipcRenderer, shell } = require('electron')
-
-document.addEventListener('click', function (event) {
-  if (event.target.tagName === 'A' && event.target.href.startsWith('http')) {
-    event.preventDefault()
-    shell.openExternal(event.target.href)
-  }
-})
+const { ipcRenderer } = require('electron')
 
 ipcRenderer.on('updatedPage', (_, url) => {
   window.location.hash = url


### PR DESCRIPTION
Prevent any URL that is not from our app to open inside one of our windows. This takes into account the recommendations of [Electron's team](https://github.com/electron/electron/blob/master/docs/tutorial/security.md).

**Update:** content security policy headers seem not to work when web security is set to false.