### PR TITLE
fix: set user model id so notifications work on windows 10

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import { store, createDaemon, showErrorMessage } from './utils'
 import startupMenubar from './menubar'
 import registerHooks from './hooks'
 
+// Sets User Model Id so notifications work on Windows 10
+app.setAppUserModelId('io.ipfs.desktop')
+
 // Only one instance can run at a time
 if (!app.requestSingleInstanceLock()) {
   dialog.showErrorBox(


### PR DESCRIPTION
Windows 10 requires us to set the user model id **and** to have the app shortcut on the startup menu. This fixes the first part. The latter was already happening.

[Docs for reference](https://electronjs.org/docs/tutorial/notifications#windows).

Didn't find a way to try notifications out without building and installing, but they seem to be working.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>