### PR TITLE
feat: create draft release on tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:webui:minimize": "shx rm -rf src/hooks/webui/app/static/js/*.map && shx rm -rf src/hooks/webui/app/static/css/*.map",
     "build:icons": "svgr -d src/icons node_modules/ipfs-css/icons && standard --fix src/icons/*.js",
     "build:babel": "babel src --ignore src/hooks/webui/app --out-dir out --copy-files",
-    "build:binaries": "electron-builder -p never"
+    "build:binaries": "electron-builder -p onTag"
   },
   "pre-commit": [
     "lint"
@@ -57,7 +57,8 @@
     "nsis": {
       "include": "build/nsis.nsh",
       "oneClick": false
-    }
+    },
+    "publish": ["github"]
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",


### PR DESCRIPTION
Adds the required info to auto-upload the binaries to GitHub. By default, the created releases are supposed to be only `drafts`. We can then review them and publish.

We still need to add the required env variable to Jenkins.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>