### PR TITLE
fix: execute IPFS binary in asar

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { app, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
-import { store, createDaemon, showErrorMessage } from './utils'
+import { store, createDaemon, showErrorMessage, logger } from './utils'
 import startupMenubar from './menubar'
 import registerHooks from './hooks'
 
@@ -49,6 +49,8 @@ async function run () {
     // Register hooks
     await registerHooks(ctx)
   } catch (e) {
+    logger.error(e)
+
     if (e.message === 'exit') {
       app.exit(1)
     } else {

--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -1,12 +1,14 @@
 import IPFSFactory from 'ipfsd-ctl'
 import { showConnFailureErrorMessage } from './errors'
-import { join } from 'path'
-import { spawnSync } from 'child_process'
+import logger from './logger'
+import { app } from 'electron'
+import { execFileSync } from 'child_process'
 import findExecutable from 'ipfsd-ctl/src/utils/find-ipfs-executable'
 
 function repoFsck (path) {
-  const exec = findExecutable('go', join(__dirname, '..'))
-  spawnSync(exec, ['repo', 'fsck'], {
+  logger.info(`Running 'ipfs repo fsck' on %s`, path)
+  let exec = findExecutable('go', app.getAppPath())
+  execFileSync(exec, ['repo', 'fsck'], {
     env: {
       ...process.env,
       IPFS_PATH: path
@@ -65,6 +67,7 @@ export default async function (opts) {
       throw e
     }
 
+    logger.warn('Connection refused due to API or Lock files')
     if (!showConnFailureErrorMessage(ipfsd.repoPath, ipfsd.apiAddr)) {
       throw new Error('exit')
     }


### PR DESCRIPTION
Fixes issue where it couldn't find the IPFS binary to execute commands through `spawn`. We now use `execFile`.

It's a documented limitation: https://electronjs.org/docs/tutorial/application-packaging#executing-binaries-inside-asar-archive

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>