### PR TITLE
fix: cleanup before starting (fixes #746)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,11 +18,6 @@ if (!app.requestSingleInstanceLock()) {
 }
 
 function handleError (e) {
-  // This is a special error used internally to close the app with status 1.
-  if (e.message === 'IPFS_DESKTOP_EXIT') {
-    return app.exit(1)
-  }
-
   logger.error(e)
   showErrorMessage(e)
 }
@@ -38,11 +33,15 @@ async function run () {
     app.exit(1)
   }
 
-  autoUpdater.allowPrerelease = true
-  // TODO: enable before releasing 0.6.0
-  // autoUpdater.checkForUpdatesAndNotify()
+  try {
+    autoUpdater.allowPrerelease = true
+    // TODO: enable before releasing 0.6.0
+    // autoUpdater.checkForUpdatesAndNotify()
 
-  await startup()
+    await startup()
+  } catch (e) {
+    handleError(e)
+  }
 }
 
 run()

--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -16,6 +16,29 @@ function repoFsck (path) {
   })
 }
 
+function startStop (path) {
+  logger.info('Starting daemon to clean up the locks')
+  const opts = {
+    env: {
+      ...process.env,
+      IPFS_PATH: path
+    },
+    timeout: 10000,
+    killSignal: 'SIGINT',
+    stdio: 'inherit'
+  }
+  let out = ''
+  try {
+    const exec = findExecutable('go', app.getAppPath())
+    out = execFileSync(exec, ['daemon'], opts)
+    console.log(out)
+    
+  } catch (e) {
+    console.log(out)
+    if (!e.message.includes('ETIMEDOUT')) throw e
+  }
+}
+
 async function spawn ({ type, path, keysize }) {
   const factory = IPFSFactory.create({ type: type })
 
@@ -57,6 +80,7 @@ export default async function (opts) {
   const ipfsd = await spawn(opts)
 
   if (!ipfsd.started) {
+    await startStop(ipfsd.repoPath)
     await start(ipfsd, opts)
   }
 

--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -1,11 +1,19 @@
 import IPFSFactory from 'ipfsd-ctl'
-import { showConnFailureErrorMessage } from './errors'
 import logger from './logger'
+import fs from 'fs-extra'
+import { join } from 'path'
 import { app } from 'electron'
 import { execFileSync } from 'child_process'
 import findExecutable from 'ipfsd-ctl/src/utils/find-ipfs-executable'
 
-function repoFsck (path) {
+async function cleanup (path) {
+  logger.info(`Entering cleanup stage`)
+
+  if (!await fs.pathExists(join(path, 'config'))) {
+    logger.info(`'config' file does not exist. Aborting cleanup`)
+    return
+  }
+
   logger.info(`Running 'ipfs repo fsck' on %s`, path)
   let exec = findExecutable('go', app.getAppPath())
   execFileSync(exec, ['repo', 'fsck'], {
@@ -14,29 +22,6 @@ function repoFsck (path) {
       IPFS_PATH: path
     }
   })
-}
-
-function startStop (path) {
-  logger.info('Starting daemon to clean up the locks')
-  const opts = {
-    env: {
-      ...process.env,
-      IPFS_PATH: path
-    },
-    timeout: 10000,
-    killSignal: 'SIGINT',
-    stdio: 'inherit'
-  }
-  let out = ''
-  try {
-    const exec = findExecutable('go', app.getAppPath())
-    out = execFileSync(exec, ['daemon'], opts)
-    console.log(out)
-    
-  } catch (e) {
-    console.log(out)
-    if (!e.message.includes('ETIMEDOUT')) throw e
-  }
 }
 
 async function spawn ({ type, path, keysize }) {
@@ -80,25 +65,10 @@ export default async function (opts) {
   const ipfsd = await spawn(opts)
 
   if (!ipfsd.started) {
-    await startStop(ipfsd.repoPath)
+    await cleanup(ipfsd.repoPath)
     await start(ipfsd, opts)
   }
 
-  try {
-    await ipfsd.api.id()
-  } catch (e) {
-    if (!e.message.includes('ECONNREFUSED')) {
-      throw e
-    }
-
-    logger.warn('Connection refused due to API or Lock files')
-    if (!showConnFailureErrorMessage(ipfsd.repoPath, ipfsd.apiAddr)) {
-      throw new Error('IPFS_DESKTOP_EXIT')
-    }
-
-    repoFsck(ipfsd.repoPath)
-    await start(ipfsd, opts)
-  }
-
+  await ipfsd.api.id()
   return ipfsd
 }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -37,18 +37,3 @@ export function showErrorMessage (e) {
 
   app.exit(1)
 }
-
-export function showConnFailureErrorMessage (path, addr) {
-  const option = dialog.showMessageBox({
-    type: 'warning',
-    title: 'IPFS Desktop',
-    message: `IPFS Desktop failed to connect to an existing ipfs api at ${addr}. This can happen if you run 'ipfs daemon' manually and it has not shutdown cleanly. Would you like to try running 'ipfs repo fsck' to remove the lock and api files from ${path} and try again?`,
-    buttons: [
-      'No, just quit',
-      'Yes, run "ipfs repo fsck"'
-    ],
-    cancelId: 0
-  })
-
-  return option === 1
-}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 import createDaemon from './daemon'
 import logo from './logo'
-import { showConnFailureErrorMessage, showErrorMessage } from './errors'
+import { showErrorMessage } from './errors'
 import store from './store'
 import logger from './logger'
 import i18n from './i18n'
@@ -11,6 +11,5 @@ export {
   store,
   logger,
   i18n,
-  showErrorMessage,
-  showConnFailureErrorMessage
+  showErrorMessage
 }


### PR DESCRIPTION
If there is a `config` file, we run `ipfs repo fsck` command to cleanup the lock files. If there is no `config` file, we expect a remote daemon so we do nothing.

`repo fsck` isn't supposed to remove the locks if a daemon is already running so there is no issue (tested on Windows).