### PR TITLE
feat: improve UX on macOS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ async function run () {
     // TODO: enable before releasing 0.6.0
     // autoUpdater.checkForUpdatesAndNotify()
 
-    await startup()
+    await startup(app)
   } catch (e) {
     handleError(e)
   }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,8 +7,8 @@ import downloadHash from './download-hash'
 import ipfsStats from './ipfs-stats'
 import takeScreenshot from './take-screenshot'
 
-export default async function () {
-  let ctx = {}
+export default async function (app) {
+  let ctx = { app }
 
   await registerDaemon(ctx) // ctx.ipfsd
   await registerMenubar(ctx) // ctx.sendToMenubar

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -30,7 +30,6 @@ export default async function (ctx) {
 
     const ready = () => {
       logger.info('Menubar is ready')
-      menubar.tray.setHighlightMode('always')
       resolve()
     }
 

--- a/src/lib/webui/preload.js
+++ b/src/lib/webui/preload.js
@@ -25,3 +25,14 @@ const apiAddress = urlParams.get('api')
 
 // Inject api address
 window.localStorage.setItem('ipfsApi', apiAddress)
+
+// Allow webui window to be dragged on mac
+document.addEventListener('DOMContentLoaded', function (event) {
+  var windowTopBar = document.createElement('div')
+  windowTopBar.style.width = '100%'
+  windowTopBar.style.height = '32px'
+  windowTopBar.style.position = 'absolute'
+  windowTopBar.style.top = windowTopBar.style.left = 0
+  windowTopBar.style.webkitAppRegion = 'drag'
+  document.body.appendChild(windowTopBar)
+})


### PR DESCRIPTION
- Hide titlebar and integrate traffic-light controls into app. This looks cooler. FACT.
- Show IPFS icon in dock and app switcher when webui window open. You can now tab back into the webui window after jumping to a finder window to get your files.

**Integrated menubar controls**
<img width="1551" alt="screenshot 2018-12-20 at 12 25 50" src="https://user-images.githubusercontent.com/58871/50284953-924f2300-0452-11e9-91a8-af169b985aca.png">

**App icon in dock and app switcher when webui window open**
![ipfs-desktop-macos](https://user-images.githubusercontent.com/58871/50284854-48663d00-0452-11e9-9ff2-02d83df728cb.gif)


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>