### PR TITLE
fix: only call dock methods if it exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ async function run () {
     // TODO: enable before releasing 0.6.0
     // autoUpdater.checkForUpdatesAndNotify()
 
-    await startup(app)
+    await startup()
   } catch (e) {
     handleError(e)
   }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,8 +7,8 @@ import downloadHash from './download-hash'
 import ipfsStats from './ipfs-stats'
 import takeScreenshot from './take-screenshot'
 
-export default async function (app) {
-  let ctx = { app }
+export default async function () {
+  let ctx = {}
 
   await registerDaemon(ctx) // ctx.ipfsd
   await registerMenubar(ctx) // ctx.sendToMenubar

--- a/src/lib/webui/index.js
+++ b/src/lib/webui/index.js
@@ -33,7 +33,7 @@ const createWindow = (ctx) => {
 
   window.on('close', (event) => {
     event.preventDefault()
-    ctx.app.dock.hide()
+    if (app.dock) app.dock.hide()
     window.hide()
     logger.info('WebUI screen was hidden')
   })
@@ -50,7 +50,7 @@ export default async function (ctx) {
     window.webContents.send('updatedPage', url)
     window.show()
     window.focus()
-    ctx.app.dock.show()
+    if (app.dock) app.dock.show()
   })
 
   app.on('before-quit', () => {


### PR DESCRIPTION
This fixes a bug from #760 where the `app.dock` object only exists on macOS. We now only use it if is exists, preventing errors on other platforms.

Also, removed the `app` object from the context because it was making the code redundant.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>