### PR TITLE
fix: open external links in default browser

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,12 +9,10 @@ import takeScreenshot from './take-screenshot'
 
 export default async function () {
   let ctx = {}
-
+  await openExternal(ctx)
   await registerDaemon(ctx) // ctx.ipfsd
   await registerMenubar(ctx) // ctx.sendToMenubar
   await registerWebUI(ctx) // ctx.sendToWebUI
-
-  await openExternal(ctx)
   await autoLaunch(ctx)
   await downloadHash(ctx)
   await takeScreenshot(ctx)


### PR DESCRIPTION
We just need to change the hooks order to fix this one.

Fixes #767.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>