### PR TITLE
feat: quit with context menu

### DIFF
--- a/src/lib/download-hash.js
+++ b/src/lib/download-hash.js
@@ -51,11 +51,11 @@ async function saveFile (dir, file) {
 }
 
 function handler (ctx) {
-  const { ipfsd } = ctx
+  const { getIpfsd } = ctx
 
   return async () => {
     const text = clipboard.readText().trim()
-    const ipfs = ipfsd.api
+    const ipfs = getIpfsd().api
 
     if (!ipfs || !text) {
       return

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -12,9 +12,9 @@ export default async function () {
   let ctx = {}
   await appMenu()
   await openExternal(ctx)
-  await registerDaemon(ctx) // ctx.ipfsd
-  await registerMenubar(ctx) // ctx.sendToMenubar
+  await registerDaemon(ctx) // ctx.getIpfsd, ctx.stopIpfs, ctx.startIpfs
   await registerWebUI(ctx) // ctx.sendToWebUI, ctx.launchWebUI
+  await registerMenubar(ctx) // ctx.sendToMenubar
   await autoLaunch(ctx)
   await downloadHash(ctx)
   await takeScreenshot(ctx)

--- a/src/lib/ipfs-stats.js
+++ b/src/lib/ipfs-stats.js
@@ -1,10 +1,12 @@
 import { ipcMain } from 'electron'
 import filesize from 'filesize'
+import { logger } from '../utils'
 
 const ipfsState = (ctx) => async () => {
-  const { ipfsd, sendToMenubar } = ctx
+  const { getIpfsd, sendToMenubar } = ctx
+  const ipfsd = getIpfsd()
 
-  if (ipfsd.started) {
+  if (ipfsd && ipfsd.started) {
     sendToMenubar('ipfs.started', (await ipfsd.api.id()))
     getPeers(ctx)()
     getRepoSize(ctx)()
@@ -13,8 +15,10 @@ const ipfsState = (ctx) => async () => {
   }
 }
 
-const getPeers = ({ sendToMenubar, ipfsd }) => async () => {
-  if (ipfsd.started) {
+const getPeers = ({ sendToMenubar, getIpfsd }) => async () => {
+  const ipfsd = getIpfsd()
+
+  if (ipfsd && ipfsd.started) {
     const peers = await ipfsd.api.swarm.peers()
     sendToMenubar('peersCount', peers.length)
   } else {
@@ -22,8 +26,10 @@ const getPeers = ({ sendToMenubar, ipfsd }) => async () => {
   }
 }
 
-const getRepoSize = ({ sendToMenubar, ipfsd }) => async () => {
-  if (ipfsd.started) {
+const getRepoSize = ({ sendToMenubar, getIpfsd }) => async () => {
+  const ipfsd = getIpfsd()
+
+  if (ipfsd && ipfsd.started) {
     const stats = await ipfsd.api.repo.stat()
     const size = stats.repoSize.toFixed(0)
     sendToMenubar('repoSize', filesize(size, { round: 0 }))
@@ -35,6 +41,20 @@ const getRepoSize = ({ sendToMenubar, ipfsd }) => async () => {
 export default function (ctx) {
   ipcMain.on('ipfs.running', ipfsState(ctx))
   ipfsState(ctx)()
+
+  ipcMain.on('ipfs.toggle', async () => {
+    try {
+      if (ctx.getIpfsd()) {
+        await ctx.stopIpfs()
+      } else {
+        await ctx.startIpfs()
+      }
+
+      ipfsState(ctx)()
+    } catch (e) {
+      logger.error(e)
+    }
+  })
 
   setInterval(getPeers(ctx), 30 * 1000)
   setInterval(getRepoSize(ctx), 60 * 60 * 1000)

--- a/src/lib/menubar/app/App.js
+++ b/src/lib/menubar/app/App.js
@@ -32,7 +32,7 @@ const Button = ({ children, on, ...props }) => (
   </button>
 )
 
-const Menubar = ({ t, ipfsIsRunning, doQuitApp, currentConfig }) => (
+const Menubar = ({ t, ipfsIsRunning, doToggleIpfs, currentConfig }) => (
   <div className='bg-navy sans-serif h-100'>
     <div className='pa3 bw3 bb b--aqua'>
       <div className='flex items-center'>
@@ -42,7 +42,7 @@ const Menubar = ({ t, ipfsIsRunning, doQuitApp, currentConfig }) => (
           online={ipfsIsRunning} />
         <div className='montserrat f3 ml2 white' style={{ marginRight: 'auto' }}>IPFS</div>
 
-        <Button onClick={doQuitApp} on={ipfsIsRunning} title={t('turnOff')}>
+        <Button onClick={doToggleIpfs} on={ipfsIsRunning} title={t('turnOff')}>
           <GlyphPower className='w2 h2' />
         </Button>
       </div>
@@ -59,7 +59,7 @@ const Menubar = ({ t, ipfsIsRunning, doQuitApp, currentConfig }) => (
 )
 
 export default connect(
-  'doQuitApp',
+  'doToggleIpfs',
   'doIpfsStartListening',
   'selectIpfsIsRunning',
   'selectCurrentConfig',

--- a/src/lib/menubar/app/App.js
+++ b/src/lib/menubar/app/App.js
@@ -42,7 +42,7 @@ const Menubar = ({ t, ipfsIsRunning, doToggleIpfs, currentConfig }) => (
           online={ipfsIsRunning} />
         <div className='montserrat f3 ml2 white' style={{ marginRight: 'auto' }}>IPFS</div>
 
-        <Button onClick={doToggleIpfs} on={ipfsIsRunning} title={t('turnOff')}>
+        <Button onClick={doToggleIpfs} on={ipfsIsRunning} title={t('toggleIpfs')}>
           <GlyphPower className='w2 h2' />
         </Button>
       </div>

--- a/src/lib/menubar/app/bundles/electron.js
+++ b/src/lib/menubar/app/bundles/electron.js
@@ -3,8 +3,8 @@ import { ipcRenderer } from 'electron'
 export default {
   name: 'electron',
 
-  doQuitApp: () => async () => {
-    ipcRenderer.send('app.quit')
+  doToggleIpfs: () => async () => {
+    ipcRenderer.send('ipfs.toggle')
   },
 
   doOpenWebUI: (url) => async () => {

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -24,7 +24,7 @@ export default async function (ctx) {
   return new Promise(resolve => {
     const menubar = new Menubar({
       index: `file://${__dirname}/app/index.html`,
-      icon: logo('ice'),
+      icon: logo('black'),
       tooltip: i18n.t('ipfsNode'),
       preloadWindow: true,
       window: {
@@ -43,6 +43,12 @@ export default async function (ctx) {
     menubar.tray.setContextMenu(getContextMenu(ctx))
 
     ctx.sendToMenubar = (type, ...args) => {
+      if (type === 'ipfs.started') {
+        menubar.tray.setImage(logo('ice'))
+      } else if (type === 'ipfs.stopped') {
+        menubar.tray.setImage(logo('black'))
+      }
+
       if (menubar && menubar.window && menubar.window.webContents) {
         menubar.window.webContents.send(type, ...args)
       }

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -1,6 +1,24 @@
 import { Menubar } from 'electron-menubar'
 import { logo, logger, i18n } from '../../utils'
-import { app, ipcMain } from 'electron'
+import { Menu, shell, app, ipcMain } from 'electron'
+
+function getContextMenu ({ launchWebUI }) {
+  return Menu.buildFromTemplate([
+    {
+      label: 'Quit',
+      click: () => { app.quit() }
+    },
+    { type: 'separator' },
+    {
+      label: 'Settings',
+      click: () => { launchWebUI('/settings') }
+    },
+    {
+      label: 'Logs Directory',
+      click: () => { shell.openItem(app.getPath('userData')) }
+    }
+  ])
+}
 
 export default async function (ctx) {
   return new Promise(resolve => {
@@ -22,6 +40,8 @@ export default async function (ctx) {
       }
     })
 
+    menubar.tray.setContextMenu(getContextMenu(ctx))
+
     ctx.sendToMenubar = (type, ...args) => {
       if (menubar && menubar.window && menubar.window.webContents) {
         menubar.window.webContents.send(type, ...args)
@@ -32,10 +52,6 @@ export default async function (ctx) {
       logger.info('Menubar is ready')
       resolve()
     }
-
-    ipcMain.on('app.quit', () => {
-      app.quit()
-    })
 
     if (menubar.isReady()) ready()
     else menubar.on('ready', ready)

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -1,6 +1,6 @@
 import { Menubar } from 'electron-menubar'
 import { logo, logger, i18n } from '../../utils'
-import { Menu, shell, app, ipcMain } from 'electron'
+import { Menu, shell, app } from 'electron'
 
 function getContextMenu ({ launchWebUI }) {
   return Menu.buildFromTemplate([

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -5,16 +5,16 @@ import { Menu, shell, app } from 'electron'
 function getContextMenu ({ launchWebUI }) {
   return Menu.buildFromTemplate([
     {
-      label: 'Quit',
+      label: i18n.t('quit'),
       click: () => { app.quit() }
     },
     { type: 'separator' },
     {
-      label: 'Settings',
+      label: i18n.t('settings'),
       click: () => { launchWebUI('/settings') }
     },
     {
-      label: 'Logs Directory',
+      label: i18n.t('logsDirectory'),
       click: () => { shell.openItem(app.getPath('userData')) }
     }
   ])

--- a/src/lib/take-screenshot.js
+++ b/src/lib/take-screenshot.js
@@ -42,9 +42,15 @@ function onError (e) {
 }
 
 function handleScreenshot (ctx) {
-  let { ipfsd, launchWebUI } = ctx
+  let { getIpfsd, launchWebUI } = ctx
 
   return async (_, output) => {
+    const ipfsd = getIpfsd()
+
+    if (!ipfsd) {
+      return
+    }
+
     const ipfs = ipfsd.api
 
     if (!ipfs) {

--- a/src/lib/webui/index.js
+++ b/src/lib/webui/index.js
@@ -42,7 +42,7 @@ const createWindow = (ctx) => {
 }
 
 export default async function (ctx) {
-  const apiAddress = ctx.ipfsd.apiAddr
+  const apiAddress = ctx.getIpfsd().apiAddr
   const window = createWindow(ctx)
 
   ctx.sendToWebUI = (...args) => window.webContents.send(...args)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,9 +1,11 @@
 {
-  "turnOff": "Turn off IPFS Desktop",
+  "toggleIpfs": "Toggle IPFS",
   "ipfsNode": "IPFS Node",
   "status": "Status",
   "files": "Files",
   "explore": "Explore",
   "peers": "Peers",
-  "settings": "Settings"
+  "settings": "Settings",
+  "quit": "Quit",
+  "logsDirectory": "Logs Directory"
 }


### PR DESCRIPTION
This fixes #764 by using the toggler in the menubar itself only for IPFS and adding a context menu that can be used for three things: quit the app, quick access to settings and logs directory, which might be useful.

![ex](https://user-images.githubusercontent.com/5447088/50646758-cb1ceb00-0f6e-11e9-806b-4615ecf2873a.gif)

![2](https://user-images.githubusercontent.com/5447088/50646801-edaf0400-0f6e-11e9-983d-64c7c225a66c.gif)

This works well on Windows. Please test on macOS and Linux!!