### PR TITLE
fix: always check if IPFSD is not null

### DIFF
--- a/src/lib/download-hash.js
+++ b/src/lib/download-hash.js
@@ -55,9 +55,9 @@ function handler (ctx) {
 
   return async () => {
     const text = clipboard.readText().trim()
-    const ipfs = getIpfsd().api
+    const ipfsd = getIpfsd()
 
-    if (!ipfs || !text) {
+    if (!ipfsd || !text) {
       return
     }
 
@@ -70,7 +70,7 @@ function handler (ctx) {
     }
 
     try {
-      const files = await ipfs.get(text)
+      const files = await ipfsd.api.get(text)
       logger.info(`Hash ${text} downloaded.`)
 
       const dir = await selectDirectory(ctx)

--- a/src/lib/register-daemon.js
+++ b/src/lib/register-daemon.js
@@ -22,6 +22,10 @@ export default async function (ctx) {
   }
 
   ctx.stopIpfs = async () => {
+    if (!ipfsd) {
+      return
+    }
+
     if (!fs.pathExists(join(ipfsd.repoPath, 'config'))) {
       // Is remote api... ignore
       ipfsd = null


### PR DESCRIPTION
Check if `ipfsd` it not null before doing the operations. Otherwise it would error.

icense: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>