### PR TITLE
feat: handle ipfs://, ipns:// and dweb: protocols

### DIFF
--- a/build/nsis.nsh
+++ b/build/nsis.nsh
@@ -26,6 +26,7 @@ ManifestDPIAware true
 !macro customInstall
   !insertmacro AddProtocolHandler "ipfs" "IPFS"
   !insertmacro AddProtocolHandler "ipns" "IPNS"
+  !insertmacro AddProtocolHandler "dweb" "DWEB"
   !insertmacro AddToShell
 !macroend
 

--- a/build/nsis.nsh
+++ b/build/nsis.nsh
@@ -1,16 +1,36 @@
 ManifestDPIAware true
 
-!macro customInstall
-  WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop" "Icon" "$appExe,0"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop\command" "" "$appExe --add=$\"%1$\""
+!macro AddToShellSpecific Where
+  DeleteRegKey SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop" "Icon" "$appExe,0"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop\command" "" "$appExe --add=$\"%1$\""
+!macroend
 
-  WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop" "Icon" "$appExe,0"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop\command" "" "$appExe --add=$\"%1$\""
+!macro AddToShell
+  DetailPrint "Adding to Context Menu"
+  !insertmacro AddToShellSpecific "*"
+  !insertmacro AddToShellSpecific "Directory"
+!macroend
+
+!macro AddProtocolHandler Protocol Description
+  DeleteRegKey SHELL_CONTEXT "Software\Classes\${Protocol}"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}" "" "${Description}"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}" "URL Protocol" ""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\DefaultIcon" "" "$appExe,0"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell" "" ""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell\open" "" ""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell\open\command" "" "$appExe %1"
+!macroend
+
+!macro customInstall
+  !insertmacro AddProtocolHandler "ipfs" "IPFS"
+  !insertmacro AddProtocolHandler "ipns" "IPNS"
+  !insertmacro AddToShell
 !macroend
 
 !macro customUnInstall
+  DeleteRegKey SHELL_CONTEXT "ipfs"
   DeleteRegKey SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop"
   DeleteRegKey SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop"
 !macroend

--- a/package.json
+++ b/package.json
@@ -60,6 +60,18 @@
     },
     "publish": [
       "github"
+    ],
+    "protocols": [
+      {
+        "name": "IPFS",
+        "role": "Viewer",
+        "schemes": ["ipfs"]
+      },
+      {
+        "name": "IPNS",
+        "role": "Viewer",
+        "schemes": ["ipns"]
+      }
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
         "name": "IPNS",
         "role": "Viewer",
         "schemes": ["ipns"]
+      },
+      {
+        "name": "DWEB",
+        "role": "Viewer",
+        "schemes": ["dweb"]
       }
     ]
   },

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,7 @@ import ipfsStats from './ipfs-stats'
 import takeScreenshot from './take-screenshot'
 import appMenu from './app-menu'
 import secondInstance from './second-instance'
+import protocolHandlers from './protocol-handlers'
 
 export default async function () {
   let ctx = {}
@@ -16,6 +17,7 @@ export default async function () {
   await registerDaemon(ctx) // ctx.getIpfsd, ctx.stopIpfs, ctx.startIpfs
   await registerWebUI(ctx) // ctx.sendToWebUI, ctx.launchWebUI
   await registerMenubar(ctx) // ctx.sendToMenubar
+  await protocolHandlers(ctx)
   await secondInstance(ctx)
   await autoLaunch(ctx)
   await downloadHash(ctx)

--- a/src/lib/protocol-handlers.js
+++ b/src/lib/protocol-handlers.js
@@ -24,7 +24,10 @@ export default function () {
   }
 
   // Handle URLs in macOS
-  app.on('open-url', (_, url) => { parseUrl(url) })
+  app.on('open-url', (event, url) => {
+    event.preventDefault()
+    parseUrl(url)
+  })
 
   // Handle URLs on Windows (hopefully on Linux too)
   app.on('second-instance', (_, argv) => {

--- a/src/lib/protocol-handlers.js
+++ b/src/lib/protocol-handlers.js
@@ -1,0 +1,35 @@
+import { app, shell } from 'electron'
+
+function openLink (protocol, part) {
+  shell.openExternal(`https://ipfs.io/${protocol}/${part}`)
+}
+
+function parseUrl (url) {
+  if (url.startsWith('ipfs://')) {
+    openLink('ipfs', url.slice(7))
+  } else if (url.startsWith('ipns://')) {
+    openLink('ipns', url.slice(7))
+  } else if (url.startsWith('dweb:/ipfs/')) {
+    openLink('ipns', url.slice(11))
+  } else if (url.startsWith('dweb:/ipns/')) {
+    openLink('ipns', url.slice(11))
+  }
+}
+
+export default function () {
+  // Handle if the app started running now, and a link
+  // was sent to be handled.
+  for (const arg in process.argv) {
+    parseUrl(arg)
+  }
+
+  // Handle URLs in macOS
+  app.on('open-url', (_, url) => { parseUrl(url) })
+
+  // Handle URLs on Windows (hopefully on Linux too)
+  app.on('second-instance', (_, argv) => {
+    for (const arg in argv) {
+      parseUrl(arg)
+    }
+  })
+}

--- a/src/lib/protocol-handlers.js
+++ b/src/lib/protocol-handlers.js
@@ -19,7 +19,7 @@ function parseUrl (url) {
 export default function () {
   // Handle if the app started running now, and a link
   // was sent to be handled.
-  for (const arg in process.argv) {
+  for (const arg of process.argv) {
     parseUrl(arg)
   }
 
@@ -28,7 +28,7 @@ export default function () {
 
   // Handle URLs on Windows (hopefully on Linux too)
   app.on('second-instance', (_, argv) => {
-    for (const arg in argv) {
+    for (const arg of argv) {
       parseUrl(arg)
     }
   })

--- a/src/lib/protocol-handlers.js
+++ b/src/lib/protocol-handlers.js
@@ -10,7 +10,7 @@ function parseUrl (url) {
   } else if (url.startsWith('ipns://')) {
     openLink('ipns', url.slice(7))
   } else if (url.startsWith('dweb:/ipfs/')) {
-    openLink('ipns', url.slice(11))
+    openLink('ipfs', url.slice(11))
   } else if (url.startsWith('dweb:/ipns/')) {
     openLink('ipns', url.slice(11))
   }

--- a/src/lib/second-instance.js
+++ b/src/lib/second-instance.js
@@ -1,4 +1,4 @@
-import { app, shell } from 'electron'
+import { app } from 'electron'
 import { extname, basename } from 'path'
 import { logger, i18n, notify, notifyError } from '../utils'
 
@@ -66,23 +66,11 @@ async function addToIpfs ({ getIpfsd, launchWebUI }, file) {
   })
 }
 
-function openLink (protocol, part) {
-  shell.openExternal(`https://ipfs.io/${protocol}/${part}`)
-}
-
 export default async function (ctx) {
   const handler = (_, argv) => {
     for (const arg of argv) {
       if (arg.startsWith('--add')) {
         return addToIpfs(ctx, arg.slice(6))
-      } else if (arg.startsWith('ipfs://')) {
-        return openLink('ipfs', arg.slice(7))
-      } else if (arg.startsWith('ipns://')) {
-        return openLink('ipns', arg.slice(7))
-      } else if (arg.startsWith('dweb:/ipfs/')) {
-        return openLink('ipns', arg.slice(11))
-      } else if (arg.startsWith('dweb:/ipns/')) {
-        return openLink('ipns', arg.slice(11))
       }
     }
   }


### PR DESCRIPTION
Ref.: #807

- Implements `ipfs://`, `ipns://`, `dweb:/ipfs/` and `dweb:/ipns/` protocol handlers.
- It required some more configuration on Windows since Electron Builder doesn't automatically add the handler configuration to NSIS script (see https://github.com/electron-userland/electron-builder/issues/623).
- On macOS and Linux it is supposed to work. Please try out.