### PR TITLE
feat: improve add to IPFS handler

### DIFF
--- a/build/nsis.nsh
+++ b/build/nsis.nsh
@@ -3,11 +3,11 @@ ManifestDPIAware true
 !macro customInstall
   WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
   WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop" "Icon" "$appExe,0"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop\command" "" "$appExe --add=$\"%1$\""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\*\shell\ipfs-desktop\command" "" "$appExe %1"
 
   WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
   WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop" "Icon" "$appExe,0"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop\command" "" "$appExe --add=$\"%1$\""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\Directory\shell\ipfs-desktop\command" "" "$appExe %1"
 !macroend
 
 !macro customUnInstall

--- a/src/lib/add-to-ipfs.js
+++ b/src/lib/add-to-ipfs.js
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import fs from 'fs-extra'
 import { extname, basename } from 'path'
 import { logger, i18n, notify, notifyError } from '../utils'
 
@@ -67,10 +68,10 @@ async function addToIpfs ({ getIpfsd, launchWebUI }, file) {
 }
 
 export default async function (ctx) {
-  const handleArgv = argv => {
-    for (const arg of argv) {
-      if (arg.startsWith('--add')) {
-        return addToIpfs(ctx, arg.slice(6))
+  const handleArgv = async argv => {
+    for (const arg of argv.slice(1)) {
+      if (await fs.pathExists(arg)) {
+        await addToIpfs(ctx, arg)
       }
     }
   }
@@ -87,5 +88,9 @@ export default async function (ctx) {
   })
 
   // Checks current proccess
-  await handleArgv(process.argv)
+  if (process.env.NODE_ENV !== 'development') {
+    await handleArgv(process.argv)
+  } else {
+    await handleArgv(process.argv.slice(3))
+  }
 }

--- a/src/lib/add-to-ipfs.js
+++ b/src/lib/add-to-ipfs.js
@@ -81,12 +81,6 @@ export default async function (ctx) {
     handleArgv(argv)
   })
 
-  // macOS drag'n'drop files on the app icon
-  app.on('open-file', (event, path) => {
-    event.preventDefault()
-    addToIpfs(ctx, path)
-  })
-
   // Checks current proccess
   if (process.env.NODE_ENV !== 'development') {
     await handleArgv(process.argv)

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,7 +7,7 @@ import downloadHash from './download-hash'
 import ipfsStats from './ipfs-stats'
 import takeScreenshot from './take-screenshot'
 import appMenu from './app-menu'
-import secondInstance from './second-instance'
+import addToIpfs from './add-to-ipfs'
 
 export default async function () {
   let ctx = {}
@@ -16,7 +16,7 @@ export default async function () {
   await registerDaemon(ctx) // ctx.getIpfsd, ctx.stopIpfs, ctx.startIpfs
   await registerWebUI(ctx) // ctx.sendToWebUI, ctx.launchWebUI
   await registerMenubar(ctx) // ctx.sendToMenubar
-  await secondInstance(ctx)
+  await addToIpfs(ctx)
   await autoLaunch(ctx)
   await downloadHash(ctx)
   await takeScreenshot(ctx)


### PR DESCRIPTION
Refactors the add handler (for context menus) and added a feature for macOS users: drop files into the icon of the app (not the tray) to add them. It probably won't work if the app is not yet running because the event is fired before starting IPFS.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>