### PR TITLE
fix: 'add to IPFS' on Windows

### DIFF
--- a/build/nsis.nsh
+++ b/build/nsis.nsh
@@ -4,7 +4,7 @@ ManifestDPIAware true
   DeleteRegKey SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop"
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop" "Icon" "$appExe,0"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop\command" "" "$appExe %1"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop\command" "" "$appExe $\"%1$\""
 !macroend
 
 !macro AddToShell
@@ -20,7 +20,7 @@ ManifestDPIAware true
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\DefaultIcon" "" "$appExe,0"
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell" "" ""
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell\open" "" ""
-  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell\open\command" "" "$appExe %1"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Protocol}\shell\open\command" "" "$appExe $\"%1$\""
 !macroend
 
 !macro customInstall


### PR DESCRIPTION
It fixes an issue where we didn't have quotes so we'd
get the short path without spaces. A file called 'Test File.mp3"
would be given as 'TEST-~1.mp3" which would be correctly added
to IPFS but with the wrong name.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>