### PR TITLE
feat: one click installer, always per-user

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     },
     "nsis": {
       "include": "build/nsis.nsh",
-      "oneClick": false
+      "oneClick": true,
+      "perMachine": false
     },
     "publish": [
       "github"


### PR DESCRIPTION
Change the Windows installer to be a one-click installer and only install per-user. This does not allow system-wide installations, i.e., for all users. I think it's a best practice and it avoids future issues with configuration collisions. This way, each user, if they want, can install IPFS Desktop in the version they want. It also simplifies installation.

![2](https://user-images.githubusercontent.com/5447088/52002184-3d72e380-24b9-11e9-8ead-35c7a67bc162.gif)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>