### PR TITLE
feat: update improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs-desktop",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.7.0",
   "productName": "IPFS Desktop",
   "description": "IPFS Native Application",
   "main": "out/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs-desktop",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.5.0",
   "productName": "IPFS Desktop",
   "description": "IPFS Native Application",
   "main": "out/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { app, dialog } from 'electron'
-import { autoUpdater } from 'electron-updater'
 import { showErrorMessage, logger } from './utils'
 import startup from './lib'
 
@@ -19,15 +18,6 @@ function handleError (e) {
 process.on('uncaughtException', handleError)
 process.on('unhandledRejection', handleError)
 
-async function checkUpdates () {
-  try {
-    autoUpdater.allowPrerelease = true
-    autoUpdater.checkForUpdatesAndNotify().catch(logger.warn)
-  } catch (e) {
-    logger.warn(e)
-  }
-}
-
 async function run () {
   try {
     await app.whenReady()
@@ -35,8 +25,6 @@ async function run () {
     dialog.showErrorBox('Electron could not start', e.stack)
     app.exit(1)
   }
-
-  checkUpdates()
 
   try {
     await startup()

--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -14,10 +14,10 @@ function updateError (error) {
 
 autoUpdater.on('error', updateError)
 
-autoUpdater.on('update-available', async info => {
+autoUpdater.on('update-available', async ({ version }) => {
   notify({
-    title: 'Update Available',
-    body: `Version ${info.version} of IPFS Desktop is available. It will be downloaded in background.`
+    title: i18n.t('updateAvailable'),
+    body: i18n.t('versionAvailableAndDownload', { version })
   })
 
   try {
@@ -29,9 +29,11 @@ autoUpdater.on('update-available', async info => {
 
 autoUpdater.on('update-downloaded', () => {
   notify({
-    title: 'Update Downloaded'
+    title: i18n.t('updateDownloaded'),
+    body: i18n.t('clickToInstall')
+  }, () => {
+    autoUpdater.quitAndInstall(true, true)
   })
-  // autoUpdater.quitAndInstall()
 })
 
 export default async function () {

--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -39,10 +39,7 @@ autoUpdater.on('update-downloaded', () => {
 export default async function () {
   try {
     await autoUpdater.checkForUpdates()
-  } catch (error) {
-    notifyError({
-      title: 'Error',
-      body: error.stack
-    })
+  } catch (_) {
+    // Ignore. The errors are already handled on 'error' event.
   }
 }

--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -1,0 +1,46 @@
+import { autoUpdater } from 'electron-updater'
+import { logger, i18n, notify, notifyError } from '../utils'
+
+autoUpdater.allowPrerelease = true
+autoUpdater.autoDownload = false
+
+function updateError (error) {
+  logger.error(error)
+  notifyError({
+    title: 'Error',
+    body: error.stack
+  })
+}
+
+autoUpdater.on('error', updateError)
+
+autoUpdater.on('update-available', async info => {
+  notify({
+    title: 'Update Available',
+    body: `Version ${info.version} of IPFS Desktop is available. It will be downloaded in background.`
+  })
+
+  try {
+    await autoUpdater.downloadUpdate()
+  } catch (error) {
+    updateError(error)
+  }
+})
+
+autoUpdater.on('update-downloaded', () => {
+  notify({
+    title: 'Update Downloaded'
+  })
+  // autoUpdater.quitAndInstall()
+})
+
+export default async function () {
+  try {
+    await autoUpdater.checkForUpdates()
+  } catch (error) {
+    notifyError({
+      title: 'Error',
+      body: error.stack
+    })
+  }
+}

--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -1,33 +1,24 @@
 import { autoUpdater } from 'electron-updater'
-import { logger, i18n, notify, notifyError } from '../utils'
+import { logger, i18n, notify } from '../utils'
 
 autoUpdater.allowPrerelease = true
 autoUpdater.autoDownload = false
 
-function updateError (error) {
-  logger.error(error)
-  notifyError({
-    title: i18n.t('updateError'),
-    body: i18n.t('errorWhileUpdating')
-  })
-}
+autoUpdater.on('error', logger.error)
 
-autoUpdater.on('error', updateError)
-
-autoUpdater.on('update-available', async ({ version }) => {
-  notify({
-    title: i18n.t('updateAvailable'),
-    body: i18n.t('versionAvailableAndDownload', { version })
-  })
+autoUpdater.on('update-available', async () => {
+  logger.info(`[updater] update available. download started`)
 
   try {
     await autoUpdater.downloadUpdate()
   } catch (error) {
-    updateError(error)
+    logger.error(error)
   }
 })
 
 autoUpdater.on('update-downloaded', () => {
+  logger.info(`[updater] update downloaded`)
+
   notify({
     title: i18n.t('updateDownloaded'),
     body: i18n.t('clickToInstall')

--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -20,7 +20,7 @@ autoUpdater.on('update-downloaded', () => {
   logger.info(`[updater] update downloaded`)
 
   notify({
-    title: i18n.t('updateDownloaded'),
+    title: i18n.t('updateAvailable'),
     body: i18n.t('clickToInstall')
   }, () => {
     autoUpdater.quitAndInstall(true, true)

--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -7,8 +7,8 @@ autoUpdater.autoDownload = false
 function updateError (error) {
   logger.error(error)
   notifyError({
-    title: 'Error',
-    body: error.stack
+    title: i18n.t('updateError'),
+    body: i18n.t('errorWhileUpdating')
   })
 }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,11 +9,13 @@ import takeScreenshot from './take-screenshot'
 import appMenu from './app-menu'
 import addToIpfs from './add-to-ipfs'
 import protocolHandlers from './protocol-handlers'
+import autoUpdater from './auto-updater'
 
 export default async function () {
   let ctx = {}
   await appMenu()
   await openExternal(ctx)
+  await autoUpdater(ctx)
   await registerDaemon(ctx) // ctx.getIpfsd, ctx.stopIpfs, ctx.startIpfs
   await registerWebUI(ctx) // ctx.sendToWebUI, ctx.launchWebUI
   await registerMenubar(ctx) // ctx.sendToMenubar

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,10 +26,6 @@
   "errorWhileWritingFiles": "An error occurred while writing the files to your file system.",
   "hashDownloaded": "Hash downloaded",
   "hashDownloadedClickToView": "Hash { hash } content downloaded. Click to view.",
-  "updateAvailable": "Update available",
-  "versionAvailableAndDownload": "Version { version } of IPFS Desktop is available and will be downloaded in background.",
   "updateDownloaded": "Update downloaded",
-  "clickToInstall": "Click here to restart and update IPFS Desktop.",
-  "updateError": "Update error",
-  "errorWhileUpdating": "An error happened while trying to update IPFS Desktop."
+  "clickToInstall": "Click here to restart and update IPFS Desktop."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,5 +25,9 @@
   "errorWhileDownloadingHash": "An error occurred while getting the hash.",
   "errorWhileWritingFiles": "An error occurred while writing the files to your file system.",
   "hashDownloaded": "Hash downloaded",
-  "hashDownloadedClickToView": "Hash { hash } content downloaded. Click to view."
+  "hashDownloadedClickToView": "Hash { hash } content downloaded. Click to view.",
+  "updateAvailable": "Update available",
+  "versionAvailableAndDownload": "Version { version } of IPFS Desktop is available and will be downloaded in background.",
+  "updateDownloaded": "Update downloaded",
+  "clickToInstall": "Click here to restart and update IPFS Desktop."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,5 +29,7 @@
   "updateAvailable": "Update available",
   "versionAvailableAndDownload": "Version { version } of IPFS Desktop is available and will be downloaded in background.",
   "updateDownloaded": "Update downloaded",
-  "clickToInstall": "Click here to restart and update IPFS Desktop."
+  "clickToInstall": "Click here to restart and update IPFS Desktop.",
+  "updateError": "Update error",
+  "errorWhileUpdating": "An error happened while trying to update IPFS Desktop."
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,6 +26,6 @@
   "errorWhileWritingFiles": "An error occurred while writing the files to your file system.",
   "hashDownloaded": "Hash downloaded",
   "hashDownloadedClickToView": "Hash { hash } content downloaded. Click to view.",
-  "updateDownloaded": "Update downloaded",
-  "clickToInstall": "Click here to restart and update IPFS Desktop."
+  "updateAvailable": "Update available",
+  "clickToInstall": "Click here to restart and install the newer version of IPFS Desktop."
 }


### PR DESCRIPTION
This PR creates a bit more manual update process. We now notify the user that there is an update available and that IPFS Desktop is going to download the new version in the background. In the end, they get a new notification telling to click on it to update.

It's a bit more manual but it helps us (and the users) get a better understanding of what's happening.

**Edit:** this also fixes #814 by not blowing up the program when there are auto-update errors. We just log them.