### PR TITLE
fix: tests & quit click

### DIFF
--- a/src/lib/register-daemon.js
+++ b/src/lib/register-daemon.js
@@ -54,7 +54,7 @@ export default async function (ctx) {
 
   await ctx.startIpfs()
 
-  app.once('will-quit', async () => {
+  app.on('before-quit', async () => {
     logger.info('[ipfsd] stopping daemon')
     await ctx.stopIpfs()
     logger.info('[ipfsd] daemon stopped')

--- a/src/lib/register-daemon.js
+++ b/src/lib/register-daemon.js
@@ -54,11 +54,9 @@ export default async function (ctx) {
 
   await ctx.startIpfs()
 
-  app.once('will-quit', async (event) => {
-    event.preventDefault()
+  app.once('will-quit', async () => {
     logger.info('[ipfsd] stopping daemon')
     await ctx.stopIpfs()
     logger.info('[ipfsd] daemon stopped')
-    app.quit()
   })
 }

--- a/src/lib/webui/index.js
+++ b/src/lib/webui/index.js
@@ -72,7 +72,7 @@ export default async function (ctx) {
   app.on('before-quit', () => {
     // Makes sure the app quits even though we prevent
     // the closing of this window.
-    window.destroy()
+    if (window) window.destroy()
   })
 
   ipcMain.on('config.get', () => {


### PR DESCRIPTION
- Fixes possible edge-case where the Web UI window was already destroyed and we try to close it.
- Do not block quitting. This possibly fixes the tests and the #776 error. If the daemon happens to not exit correctly, we always do a cleanup when it starts

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>