### PR TITLE
fix: screenshots name incompatibilities

### DIFF
--- a/src/lib/take-screenshot.js
+++ b/src/lib/take-screenshot.js
@@ -59,7 +59,10 @@ function handleScreenshot (ctx) {
     try {
       await makeScreenshotDir(ipfs)
       const isDir = output.length > 1
-      let baseName = `/screenshots/${new Date().toISOString()}`
+      const rawDate = new Date()
+      const date = `${rawDate.getFullYear()}-${rawDate.getMonth()}-${rawDate.getDate()}`
+      const time = `${date.getHours()}.${date.getMinutes()}.${date.getMilliseconds()}`
+      let baseName = `/screenshots/${date} ${time}`
 
       if (isDir) {
         baseName += '/'


### PR DESCRIPTION
Remove the character `:` from screenshots names because it is incompatible with Windows file system, which would cause some troubles downloading the files.

Fixes #830 

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>