### PR TITLE
feat: version indicators

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "electron-updater": "^4.0.6",
     "filesize": "^4.1.2",
     "fs-extra": "^7.0.1",
-    "go-ipfs-dep": "^0.4.18",
+    "go-ipfs-dep": "0.4.18",
     "i18next": "^15.0.4",
     "i18next-electron-language-detector": "0.0.10",
     "i18next-icu": "^1.1.2",

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -2,15 +2,23 @@ import { Menubar } from 'electron-menubar'
 import { logo, store, logger, i18n } from '../../utils'
 import { Menu, shell, app } from 'electron'
 
+function openReleases () {
+  shell.openItem('https://github.com/ipfs-shipyard/ipfs-desktop/releases')
+}
+
 function getContextMenu ({ launchWebUI }) {
   return Menu.buildFromTemplate([
     {
-      label: `Version ${require('../../../package.json').version}`,
+      label: i18n.t('versions'),
       enabled: false
     },
     {
-      label: `IPFS ${require('../../../package.json').dependencies['go-ipfs-dep']}`,
-      enabled: false
+      label: `ipfs-desktop ${require('../../../package.json').version}`,
+      click: openReleases
+    },
+    {
+      label: `go-ipfs ${require('../../../package.json').dependencies['go-ipfs-dep']}`,
+      click: openReleases
     },
     { type: 'separator' },
     {

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -2,10 +2,6 @@ import { Menubar } from 'electron-menubar'
 import { logo, store, logger, i18n } from '../../utils'
 import { Menu, shell, app } from 'electron'
 
-function openReleases () {
-  shell.openItem('https://github.com/ipfs-shipyard/ipfs-desktop/releases')
-}
-
 function getContextMenu ({ launchWebUI }) {
   return Menu.buildFromTemplate([
     {
@@ -14,11 +10,11 @@ function getContextMenu ({ launchWebUI }) {
     },
     {
       label: `ipfs-desktop ${require('../../../package.json').version}`,
-      click: openReleases
+      click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/releases') }
     },
     {
       label: `go-ipfs ${require('../../../package.json').dependencies['go-ipfs-dep']}`,
-      click: openReleases
+      click: () => { shell.openExternal('https://github.com/ipfs/go-ipfs/releases') }
     },
     { type: 'separator' },
     {

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -5,6 +5,15 @@ import { Menu, shell, app } from 'electron'
 function getContextMenu ({ launchWebUI }) {
   return Menu.buildFromTemplate([
     {
+      label: `Version ${require('../../../package.json').version}`,
+      enabled: false
+    },
+    {
+      label: `IPFS ${require('../../../package.json').dependencies['go-ipfs-dep']}`,
+      enabled: false
+    },
+    { type: 'separator' },
+    {
       label: i18n.t('settings'),
       click: () => { launchWebUI('/settings') }
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,6 +7,7 @@
   "peers": "Peers",
   "settings": "Settings",
   "quit": "Quit",
+  "versions": "Versions",
   "logsDirectory": "Logs Directory",
   "configFile": "Configuration File",
   "screenshotTaken": "Screenshot taken",


### PR DESCRIPTION
Closes #832 by adding Desktop and IPFS version to the top of the context menu.

![image](https://user-images.githubusercontent.com/5447088/53084011-e5e3f880-34f7-11e9-99a9-873033fac010.png)

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>