### PR TITLE
Restore Linux CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: node_js
 
 node_js:
-  - 10.4.1
-
-matrix:
-  allow_failures:
-    - os: linux
-  fast_finish: true
+  - 10.15.1
 
 os:
   - linux
   - osx
 
 before_script:
-  - ./scripts/travis-xvfb.sh
+  - . scripts/travis-xvfb.sh
 
 script:
   - npm run test

--- a/test/utils/ipfsd.js
+++ b/test/utils/ipfsd.js
@@ -16,6 +16,8 @@ async function makeRepository () {
     }, function (err, ipfsd) {
       if (err) return reject(err)
       ipfsd.init({
+        bits: 1024,
+        profile: 'test',
         directory: dir.name
       }, e => {
         if (e) return reject(e)


### PR DESCRIPTION
This fixes CI (tests) on Linux. by moving DISPLAY env variable to the main scope.

(We now run the xfvb script in the main scope rather than launching a new shell, that way `npm run test` will see `DISPLAY` if set on linux)

By the way:
- switched to the latest Node.js LTS
- go-ipfs used in tests now inits with 'test' profile and a smaller key (to save some ms)
