### PR TITLE
feat: update menubar language according to web ui's

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,4 @@
+import languageSelector from './language-selector'
 import registerDaemon from './register-daemon'
 import registerMenubar from './menubar'
 import registerWebUI from './webui'
@@ -19,6 +20,7 @@ export default async function () {
   await registerDaemon(ctx) // ctx.getIpfsd, ctx.stopIpfs, ctx.startIpfs
   await registerWebUI(ctx) // ctx.sendToWebUI, ctx.launchWebUI, ctx.updateWebUI
   await registerMenubar(ctx) // ctx.sendToMenubar, ctx.menubar
+  await languageSelector(ctx)
   await addToIpfs(ctx)
   await protocolHandlers(ctx)
   await autoLaunch(ctx)

--- a/src/lib/language-selector.js
+++ b/src/lib/language-selector.js
@@ -1,0 +1,15 @@
+import { ipcMain } from 'electron'
+import { i18n, store } from '../utils'
+
+export default async function ({ sendToMenubar }) {
+  ipcMain.on('languageUpdated', async (_, lang) => {
+    if (lang === store.get('language')) {
+      return
+    }
+
+    store.set('language', lang)
+
+    await i18n.changeLanguage(lang)
+    sendToMenubar('languageUpdated', lang)
+  })
+}

--- a/src/lib/menubar/app/index.js
+++ b/src/lib/menubar/app/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'redux-bundler-react'
+import { ipcRenderer } from 'electron'
 import App from './App'
 import getStore from './bundles'
 import registerScreenshot from './utils/screenshot'
@@ -13,5 +14,9 @@ ReactDOM.render(
       <App />
     </I18nextProvider>
   </Provider>, document.getElementById('root'))
+
+ipcRenderer.on('languageUpdated', (_, lang) => {
+  i18n.changeLanguage(lang)
+})
 
 registerScreenshot()

--- a/src/lib/menubar/index.js
+++ b/src/lib/menubar/index.js
@@ -67,9 +67,9 @@ export default async function (ctx) {
     // - Linux, Windows and the rest seems to be fine with just
     //   setting context menu
     // More: https://electronjs.org/docs/api/tray
-    const os = process.platform
-    const menu = getContextMenu(ctx)
-    if (os === 'darwin') {
+    let menu = getContextMenu(ctx)
+
+    if (process.platform === 'darwin') {
       menubar.tray.on('right-click', event => {
         event.preventDefault()
         menubar.tray.popUpContextMenu(menu)
@@ -85,6 +85,13 @@ export default async function (ctx) {
         menubar.tray.setImage(logo('ice'))
       } else if (type === 'ipfs.stopped') {
         menubar.tray.setImage(logo('black'))
+      } else if (type === 'languageUpdated') {
+        menubar.tray.setToolTip(i18n.t('ipfsNode'))
+        menu = getContextMenu(ctx)
+
+        if (process.platform !== 'darwin') {
+          menubar.tray.setContextMenu(menu)
+        }
       }
 
       if (menubar && menubar.window && menubar.window.webContents) {

--- a/src/lib/webui/index.js
+++ b/src/lib/webui/index.js
@@ -90,6 +90,6 @@ export default async function (ctx) {
       resolve()
     })
 
-    window.loadURL(`webui://-?api=${apiAddress}&lng=${app.getLocale()}#/`)
+    window.loadURL(`webui://-?api=${apiAddress}&lng=${store.get('language')}#/`)
   })
 }

--- a/src/lib/webui/preload.js
+++ b/src/lib/webui/preload.js
@@ -1,5 +1,14 @@
 const { ipcRenderer } = require('electron')
 
+var originalSetItem = window.localStorage.setItem
+window.localStorage.setItem = function () {
+  if (arguments[0] === 'i18nextLng') {
+    ipcRenderer.send('languageUpdated', arguments[1])
+  }
+
+  originalSetItem.apply(this, arguments)
+}
+
 ipcRenderer.on('updatedPage', (_, url) => {
   window.location.hash = url
 })

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -2,7 +2,7 @@ import { join } from 'path'
 import i18n from 'i18next'
 import ICU from 'i18next-icu'
 import Backend from 'i18next-node-fs-backend'
-import LanguageDetector from 'i18next-electron-language-detector'
+import store from './store'
 
 import cs from 'i18next-icu/locale-data/cs'
 import da from 'i18next-icu/locale-data/da'
@@ -22,8 +22,8 @@ const localeData = [cs, da, ca, en, fr, ko, nl, no, pl, pt, ru, zh]
 i18n
   .use(new ICU({ localeData: localeData }))
   .use(Backend)
-  .use(LanguageDetector)
   .init({
+    lng: store.get('language'),
     fallbackLng: {
       'default': ['en']
     },

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -1,3 +1,4 @@
+import electron from 'electron'
 import Store from 'electron-store'
 
 const store = new Store()
@@ -14,6 +15,10 @@ if (store.get('version') !== 5) {
   })
 
   store.set('version', 5)
+}
+
+if (!store.get('language')) {
+  store.set('language', (electron.app || electron.remote.app).getLocale())
 }
 
 export default store


### PR DESCRIPTION
Updates IPFS Desktop language according to the one set in Web UI. (Ref.: #844)

We can add a notification or something like that to guide users to Transifex when their language doesn't exist for IPFS Desktop.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>