### PR TITLE
wip: support chocolatey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 config.gypi
 src/lib/webui/app
 src/icons/*.js
+*.nupkg

--- a/pkgs/chocolatey/ipfs-desktop.nuspec
+++ b/pkgs/chocolatey/ipfs-desktop.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ipfs-desktop</id>
+    <version>0.7.0-rc.3</version>
+    <owners>Henrique Dias</owners>
+    <title>IPFS Desktop</title>
+    <authors>Protocol Labs, Inc.</authors>
+    <projectUrl>https://github.com/ipfs-shipyard/ipfs-desktop</projectUrl>
+    <packageSourceUrl>https://github.com/ipfs-shipyard/ipfs-desktop</packageSourceUrl>
+    <licenseUrl>https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/LICENSE</licenseUrl>
+    <iconUrl>http://cdn.rawgit.com/ipfs-shipyard/ipfs-desktop/master/build/icon.ico</iconUrl>
+    <tags>ipfs-desktop ipfs station decentralization utiliy</tags>
+    <summary>IPFS Desktop Application</summary>
+    <description>__REPLACE__MarkDown_Okay </description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/pkgs/chocolatey/tools/ChocolateyInstall.ps1
+++ b/pkgs/chocolatey/tools/ChocolateyInstall.ps1
@@ -1,0 +1,16 @@
+﻿$ErrorActionPreference = 'Stop';
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$packageArgs = @{
+  packageName     = $env:ChocolateyPackageName
+  unzipLocation   = $toolsDir
+  fileType        = 'EXE'
+  url64bit        = 'https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.7.0-rc.3/ipfs-desktop-setup-0.7.0-rc.3.exe'
+  softwareName    = 'IPFS Desktop*'
+  checksum64      = '09A10EFB7AF0965006D730AC8DE18B90F08220200EBD7088C8437D5094854E733BF2A97876F0C805F0719FFE7D78B2FCAD31182E260126FF7F53B71A10662C4B'
+  checksumType64  = 'sha512'
+  silentArgs      = '/S'
+  validExitCodes  = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/pkgs/chocolatey/tools/LICENSE.txt
+++ b/pkgs/chocolatey/tools/LICENSE.txt
@@ -1,0 +1,23 @@
+﻿From: https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Protocol Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkgs/chocolatey/tools/VERIFICATION.txt
+++ b/pkgs/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,6 @@
+﻿The binaries are directly downloaded from GitHub releases:
+
+- https://github.com/ipfs-shipyard/ipfs-desktop/releases
+
+Each release contains a latest.yml, which contains the SHA512
+checksum for every file encoded in base 64.


### PR DESCRIPTION
Support for Chocolatey, a package manager for Windows. For now, and unfortunately, Chocolatey doesn't support pre-release version numbers so I'm not yet sure how to make this work and/or create a build process.

What's missing?

- [ ] Build script to update version, checksum and link and then publish the package.
- [ ] Add description

**PS:** the `owners` tag is just a name for maintainers. They just use it for backwards compatibility.

Ref: #691 

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>