### PR TITLE
chore: add snap

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,6 +14,15 @@ linux:
   target:
     - AppImage
     - deb
+    - snap
+
+snap:
+  confinement: strict
+  plugs:
+    - default
+    - network
+    - network-bind
+    - removable-media
 
 publish:
   - github


### PR DESCRIPTION
Adds snap output and closes #782. `home` is included in `defaults`.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>