### PR TITLE
fix: make quitAndInstall work on macos

### DIFF
--- a/src/lib/auto-updater.js
+++ b/src/lib/auto-updater.js
@@ -1,5 +1,5 @@
 import { autoUpdater } from 'electron-updater'
-import { logger, i18n, notify } from '../utils'
+import { logger, i18n, notify, quitAndInstall } from '../utils'
 
 let userRequested = false
 
@@ -46,7 +46,9 @@ function setup () {
       title: i18n.t('updateAvailable'),
       body: i18n.t('clickToInstall')
     }, () => {
-      autoUpdater.quitAndInstall(true, true)
+      setImmediate(() => {
+        quitAndInstall()
+      })
     })
   })
 }

--- a/src/lib/register-daemon.js
+++ b/src/lib/register-daemon.js
@@ -73,7 +73,9 @@ export default async function (ctx) {
     return new Promise(resolve => {
       const ipfsdObj = ipfsd
       ipfsd = null
-      ipfsdObj.stop(err => {
+      // give ipfs 3s to stop. An unclean shutdown is preferable to making the
+      // user wait, and taking longer prevents the update mechanism from working.
+      ipfsdObj.stop(180, err => {
         if (err) {
           logger.error('[ipfsd] %v', err)
           updateStatus(STATUS.STOPPING_FAILED)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,6 +4,7 @@ import store from './store'
 import logger from './logger'
 import i18n from './i18n'
 import { notify, notifyError } from './notify'
+import quitAndInstall from './quit-and-install'
 
 export {
   createDaemon,
@@ -12,5 +13,6 @@ export {
   i18n,
   notify,
   notifyError,
-  showErrorMessage
+  showErrorMessage,
+  quitAndInstall
 }

--- a/src/utils/quit-and-install.js
+++ b/src/utils/quit-and-install.js
@@ -1,0 +1,12 @@
+import { app, BrowserWindow } from 'electron'
+import { autoUpdater } from 'electron-updater'
+
+// adapted from https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
+export default function quitAndInstall () {
+  app.removeAllListeners('window-all-closed')
+  const browserWindows = BrowserWindow.getAllWindows()
+  browserWindows.forEach(function (browserWindow) {
+    browserWindow.removeAllListeners('close')
+  })
+  autoUpdater.quitAndInstall(true, true)
+}


### PR DESCRIPTION
gotta clear all listeners on all the windows for quitAndInstall
to work. Now auto-update works as expected on mac.

thanks to the proposed fix on this issue:
https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881

fixes: https://github.com/ipfs-shipyard/ipfs-desktop/issues/851


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>