### PR TITLE
fix: file upload bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmRvPGBVDBEUvrXrinMKgh8Vu8mVBbTZk3C1jJGfgWchSP -p assets/webui/",
+    "build:webui:download": "npx ipfs-or-gateway -c QmfQkD8pBSBCBxWEwFSu4XaDVSWK6bjnNuaWZjMyQbyDub -p assets/webui/",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"


### PR DESCRIPTION
webui was failing to upload files. update to 2.4.4 for the fix.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>