### PR TITLE
fix: log fsck error instead of immediately failing

### DIFF
--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -17,13 +17,18 @@ async function cleanup (addr, path) {
 
   logger.info(`[daemon] cleanup: ipfs repo fsck ${path}`)
   let exec = findExecutable('go', app.getAppPath())
-  execFileSync(exec, ['repo', 'fsck'], {
-    env: {
-      ...process.env,
-      IPFS_PATH: path
-    }
-  })
-  logger.info(`[daemon] cleanup: completed`)
+
+  try {
+    execFileSync(exec, ['repo', 'fsck'], {
+      env: {
+        ...process.env,
+        IPFS_PATH: path
+      }
+    })
+    logger.info('[daemon] cleanup: completed')
+  } catch (e) {
+    logger.error('[daemon] %v', e)
+  }
 }
 
 async function spawn ({ type, path, keysize }) {


### PR DESCRIPTION
As per #835, I concluded that, for some reason, IPFS shut down failed and `ipfsd-ctl` wasn't connecting. Although I did not find the true reason, I decided to log the error of `fsck` instead of immediately failing. This way perhaps `start` can connect.

Also, the report is to version 0.6.1. Since then, we've made some tweaks in the shutting down logic, such as defining a timeout. For those reasons, this closes #835.