### PR TITLE
feat: simplify file adding

### DIFF
--- a/assets/build/nsis.nsh
+++ b/assets/build/nsis.nsh
@@ -6,7 +6,7 @@ ManifestDPIAware true
   DeleteRegKey SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop"
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop" "MUIVerb" "Add to IPFS"
   WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop" "Icon" "$appExe,0"
-  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop\command" "" "$appExe $\"%1$\""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\${Where}\shell\ipfs-desktop\command" "" "$appExe --add=$\"%1$\""
 !macroend
 
 !macro AddToShell

--- a/src/late/add-to-ipfs.js
+++ b/src/late/add-to-ipfs.js
@@ -5,8 +5,14 @@ import { addToIpfs } from '../utils'
 export default async function (ctx) {
   const handleArgv = async argv => {
     for (const arg of argv.slice(1)) {
-      if (await fs.pathExists(arg)) {
-        await addToIpfs(ctx, arg)
+      if (!arg.startsWith('--add')) {
+        continue
+      }
+
+      const filename = arg.slice(6)
+
+      if (await fs.pathExists(filename)) {
+        await addToIpfs(ctx, filename)
       }
     }
   }
@@ -26,9 +32,5 @@ export default async function (ctx) {
   })
 
   // Checks current proccess
-  if (process.env.NODE_ENV !== 'development') {
-    await handleArgv(process.argv)
-  } else {
-    await handleArgv(process.argv.slice(3))
-  }
+  await handleArgv(process.argv)
 }


### PR DESCRIPTION
Reverts some changes I've made to file adding. Re-adds the flag `--add` so it is easier and clear to know which elements from the args to add. This avoids unnecessary checks.

**Tested and working.Only affects Windows.**

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>