### PR TITLE
fix: move i18n to late hooks

### DIFF
--- a/src/late/auto-updater.js
+++ b/src/late/auto-updater.js
@@ -1,5 +1,6 @@
 import { autoUpdater } from 'electron-updater'
-import { logger, i18n, notify, quitAndInstall } from '../utils'
+import i18n from 'i18next'
+import { logger, notify, quitAndInstall } from '../utils'
 
 let userRequested = false
 

--- a/src/late/download-hash.js
+++ b/src/late/download-hash.js
@@ -1,8 +1,9 @@
 import path from 'path'
 import fs from 'fs-extra'
 import isIPFS from 'is-ipfs'
+import i18n from 'i18next'
 import { clipboard, app, shell, dialog, globalShortcut } from 'electron'
-import { store, logger, i18n, notify, notifyError } from '../utils'
+import { store, logger, notify, notifyError } from '../utils'
 import { createToggler } from './utils'
 
 const settingsOption = 'downloadHashShortcut'

--- a/src/late/i18n.js
+++ b/src/late/i18n.js
@@ -2,7 +2,7 @@ import { join } from 'path'
 import i18n from 'i18next'
 import ICU from 'i18next-icu'
 import Backend from 'i18next-node-fs-backend'
-import store from './store'
+import store from '../utils/store'
 
 import cs from 'i18next-icu/locale-data/cs'
 import da from 'i18next-icu/locale-data/da'
@@ -19,17 +19,17 @@ import ru from 'i18next-icu/locale-data/ru'
 
 const localeData = [cs, da, ca, en, fr, ko, nl, no, pl, pt, ru, zh]
 
-i18n
-  .use(new ICU({ localeData: localeData }))
-  .use(Backend)
-  .init({
-    lng: store.get('language'),
-    fallbackLng: {
-      'default': ['en']
-    },
-    backend: {
-      loadPath: join(__dirname, '../../assets/locales/{{lng}}.json')
-    }
-  })
-
-export default i18n
+export default async function () {
+  await i18n
+    .use(new ICU({ localeData: localeData }))
+    .use(Backend)
+    .init({
+      lng: store.get('language'),
+      fallbackLng: {
+        'default': ['en']
+      },
+      backend: {
+        loadPath: join(__dirname, '../../assets/locales/{{lng}}.json')
+      }
+    })
+}

--- a/src/late/index.js
+++ b/src/late/index.js
@@ -1,3 +1,4 @@
+import i18n from './i18n'
 import languageSelector from './language-selector'
 import registerDaemon from './register-daemon'
 import registerWebUI from './webui'
@@ -11,6 +12,7 @@ import autoUpdater from './auto-updater'
 import tray from './tray'
 
 export default async function (ctx) {
+  await i18n(ctx)
   await appMenu(ctx)
   await openExternal(ctx)
   await autoUpdater(ctx) // ctx.checkForUpdates

--- a/src/late/language-selector.js
+++ b/src/late/language-selector.js
@@ -1,5 +1,6 @@
+import i18n from 'i18next'
 import { ipcMain } from 'electron'
-import { i18n, store } from '../utils'
+import { store } from '../utils'
 
 export default function () {
   ipcMain.on('updateLanguage', async (_, lang) => {

--- a/src/late/take-screenshot.js
+++ b/src/late/take-screenshot.js
@@ -1,5 +1,6 @@
 import { clipboard, ipcMain, globalShortcut, nativeImage } from 'electron'
-import { store, notify, notifyError, logger, i18n } from '../utils'
+import i18n from 'i18next'
+import { store, notify, notifyError, logger } from '../utils'
 import { createToggler } from './utils'
 
 const settingsOption = 'screenshotShortcut'

--- a/src/late/tray.js
+++ b/src/late/tray.js
@@ -1,5 +1,6 @@
-import { store, logger, i18n } from '../utils'
+import { store, logger } from '../utils'
 import { Menu, Tray, shell, app, ipcMain } from 'electron'
+import i18n from 'i18next'
 import { STATUS } from './register-daemon'
 import path from 'path'
 import os from 'os'

--- a/src/utils/add-to-ipfs.js
+++ b/src/utils/add-to-ipfs.js
@@ -1,6 +1,6 @@
 import { extname, basename } from 'path'
 import logger from './logger'
-import i18n from './i18n'
+import i18n from 'i18next'
 import { notify, notifyError } from './notify'
 
 async function copyFile (launch, ipfs, hash, name, folder = false) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,7 +2,6 @@ import createDaemon from './daemon'
 import { showErrorMessage } from './errors'
 import store from './store'
 import logger from './logger'
-import i18n from './i18n'
 import { notify, notifyError } from './notify'
 import quitAndInstall from './quit-and-install'
 import addToIpfs from './add-to-ipfs'
@@ -11,7 +10,6 @@ export {
   createDaemon,
   store,
   logger,
-  i18n,
   notify,
   notifyError,
   showErrorMessage,

--- a/src/utils/notify.js
+++ b/src/utils/notify.js
@@ -1,5 +1,5 @@
 import { app, shell, Notification } from 'electron'
-import i18n from './i18n'
+import i18n from 'i18next'
 
 export function notify (options, onClick) {
   const not = new Notification(options)


### PR DESCRIPTION
While building other PR, I noticed the translations weren't available at early stages of startup and that's because i18n returns a promise. Here I change the mechanism so we wait for the translations to be ready.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>