### PR TITLE
feat: add snap hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 config.gypi
 assets/webui
 *.nupkg
+assets/build/snap-hooks

--- a/assets/build/after-install.sh
+++ b/assets/build/after-install.sh
@@ -2,8 +2,14 @@
 
 set -e
 
-ln -sf '/opt/${productFilename}/${executable}' '/usr/local/bin/${executable}'
+location='/opt/${productFilename}'
+
+if [ ! -z $SNAP ]; then
+  location=$SNAP
+fi
+
+ln -sf '${location}/${executable}' '/usr/local/bin/${executable}'
 
 if [ ! -f /usr/local/bin/ipfs ]; then
-  ln -sf '/opt/${productFilename}/resources/bin/ipfs.sh' '/usr/local/bin/ipfs'
+  ln -sf '${location}/resources/bin/ipfs.sh' '/usr/local/bin/ipfs'
 fi

--- a/assets/build/after-install.sh
+++ b/assets/build/after-install.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-location='/opt/${productFilename}'
+DIR='/opt/${productFilename}'
 
 if [ ! -z $SNAP ]; then
-  location=$SNAP
+  DIR=$SNAP
 fi
 
-ln -sf '${location}/${executable}' '/usr/local/bin/${executable}'
+ln -sf "$DIR/${executable}" '/usr/local/bin/${executable}'
 
 if [ ! -f /usr/local/bin/ipfs ]; then
-  ln -sf '${location}/resources/bin/ipfs.sh' '/usr/local/bin/ipfs'
+  ln -sf "$DIR/resources/bin/ipfs.sh" '/usr/local/bin/ipfs'
 fi

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,7 +53,7 @@ deb:
 
 snap:
   confinement: strict
-  hooks: assets/build/snap-hooks
+  hooks: snap-hooks/
   plugs:
     - default
     - network

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,7 +53,7 @@ deb:
 
 snap:
   confinement: strict
-  hooks: build/snap-hooks
+  hooks: assets/build/snap-hooks
   plugs:
     - default
     - network

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,7 +53,7 @@ deb:
 
 snap:
   confinement: strict
-  hooks: snap-hooks/
+  hooks: build/snap-hooks
   plugs:
     - default
     - network

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,6 +53,7 @@ deb:
 
 snap:
   confinement: strict
+  hooks: assets/build/snap-hooks
   plugs:
     - default
     - network

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "build:webui:download": "npx ipfs-or-gateway -c QmfQkD8pBSBCBxWEwFSu4XaDVSWK6bjnNuaWZjMyQbyDub -p assets/webui/",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
+    "build:snap": "run-s build:snap:*",
+    "build:snap:mkdir": "shx mkdir -p assets/build/snap-hooks",
+    "build:snap:cpinstall": "shx cp assets/build/after-install.sh assets/build/snap-hooks/install",
+    "build:snap:cpremove": "shx cp assets/build/after-remove.sh assets/build/snap-hooks/remove",
     "build:binaries": "electron-builder --publish onTag"
   },
   "pre-commit": [


### PR DESCRIPTION
So, this should add the snap hooks for install and removal to add `ipfs` to the `PATH`.

Although, building is failing with "Macro location is not defined". I couldn't find any information on Electron Builder's issues nor on Google. Everything I find is related to C... so... I'm a bit confused with what's happening.

@lidel could you take a look at the code to see if something looks wrong? I'll keep searching to try to find out what's wrong. It seems related to fpm, but I don't change any of its configuration here...