### PR TITLE
refactor: return status on createToggler

### DIFF
--- a/src/late/auto-launch.js
+++ b/src/late/auto-launch.js
@@ -24,8 +24,11 @@ export default function (ctx) {
         if (await autoLauncher.isEnabled()) await autoLauncher.disable()
         logger.info('[launch on startup] disabled')
       }
+
+      return true
     } catch (e) {
       logger.error(e.stack)
+      return false
     }
   }
 

--- a/src/late/download-hash.js
+++ b/src/late/download-hash.js
@@ -117,6 +117,8 @@ export default function (ctx) {
       globalShortcut.unregister(shortcut)
       logger.info('[hash download] shortcut disabled')
     }
+
+    return true
   }
 
   activate(store.get(settingsOption, false))

--- a/src/late/take-screenshot.js
+++ b/src/late/take-screenshot.js
@@ -107,6 +107,8 @@ export default function (ctx) {
       globalShortcut.unregister(shortcut)
       logger.info('[screenshot] shortcut disabled')
     }
+
+    return true
   }
 
   activate(store.get(settingsOption, false))

--- a/src/late/utils.js
+++ b/src/late/utils.js
@@ -3,10 +3,14 @@ import { ipcMain } from 'electron'
 
 export function createToggler ({ webui }, settingsOption, activate) {
   ipcMain.on('config.toggle', (_, opt) => {
-    if (opt === settingsOption) {
-      store.set(settingsOption, !store.get(settingsOption))
-      activate(store.get(settingsOption))
-      webui.webContents.send('config.changed', store.store)
+    if (opt !== settingsOption) {
+      return
     }
+
+    if (activate(store.get(settingsOption))) {
+      store.set(settingsOption, !store.get(settingsOption))
+    }
+
+    webui.webContents.send('config.changed', store.store)
   })
 }


### PR DESCRIPTION
Only if `activate` returns true, we change the value in the database.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>