### PR TITLE
Add .tar.xz package target

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,9 +34,13 @@ nsis:
   perMachine: false
 
 linux:
+  artifactName: ${name}-${version}-${os}-${arch}.${ext}
+  executableName: ipfs-desktop
   category: Utility
+  synopsis: A desktop client for IPFS
   maintainer: henrique@protocol.ai
   target:
+    - tar.xz
     - AppImage
     - deb
     - rpm


### PR DESCRIPTION
This adds `.tar.xz`, a generic package target that makes things easier for various user groups on Linux:
- **install without package manager** 
  - user can just download, unpack somewhere and run without access to root
  - testing on unsupported platform becomes much easier
- **create package for distributions that are not supported by our electron build**
  - package maintainers can now reuse official `tar.xz` directly, or as a part of packaging pipeline
  - to make things more predictable, we hardcoded linux artifact names to follow this convention:
    ```
    ${name}-${version}-${os}-${arch}.${ext}
    ```
    examples of produced package names:
    ```
    ipfs-desktop-0.7.2-linux-amd64.deb
    ipfs-desktop-0.7.2-linux-amd64.snap
    ipfs-desktop-0.7.2-linux-x64.tar.xz
    ipfs-desktop-0.7.2-linux-x86_64.AppImage
    ipfs-desktop-0.7.2-linux-x86_64.rpm
    ```

cc @andrew 