### PR TITLE
feat: support macOS dark mode

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,6 +7,7 @@ asarUnpack: 'out/**/scripts/**/*'
 
 mac:
   category: public.app-category.utilities
+  darkModeSupport: true
 
 dmg:
   iconSize: 160


### PR DESCRIPTION
This applies to native interfaces such as dialogs.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>