### PR TITLE
feat: don't ask to add ipfs to PATH

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -75,11 +75,5 @@
   "ipfsDesktopHasShutdownDialog": {
     "title": "IPFS Desktop has shutdown",
     "message": "IPFS Desktop has shutdown because of an error. You can restart the app or report the error to the developers, which requires a GitHub account."
-  },
-  "cmdToolsDialog": {
-    "title": "IPFS command line tools",
-    "messageWindows": "You already have the IPFS command line tools on your PATH. IPFS Desktop can pre-prepend its tools to the PATH and keep them up to date. Do you agree?",
-    "messageAlreadyExists": "IPFS Desktop detected you already have IPFS CLI installed. We can replace the existing ipfs command installed at /usr/local/bin/ipfs, and update it when new versions are available. Do you agree?",
-    "messageNotExists": "IPFS Desktop can keep the IPFS command-line interface (CLI) up to date. It will be installed at /usr/local/bin/ipfs. Do you agree?"
   }
 }

--- a/src/late/ipfs-on-path/index.js
+++ b/src/late/ipfs-on-path/index.js
@@ -1,12 +1,11 @@
 import os from 'os'
 import { join } from 'path'
-import i18n from 'i18next'
 import which from 'which'
 import { execFile } from 'child_process'
 import { createToggler } from '../utils'
 import { logger, store, execOrSudo } from '../../utils'
 import { ipcMain } from 'electron'
-import { showDialog, recoverableErrorDialog } from '../../dialogs'
+import { recoverableErrorDialog } from '../../dialogs'
 
 const SETTINGS_OPTION = 'ipfsOnPath'
 
@@ -33,28 +32,12 @@ function firstTime () {
   const ipfsExists = which.sync('ipfs', { nothrow: true }) !== null
 
   if ((isDarwin || isWindows) && !ipfsExists) {
+    // If it's macOS or Windows and IPFS is not on user's PATH, let's add it.
     logger.info('[ipfs on path] macOS/windows + ipfs not present, installing')
     ipcMain.emit('config.toggle', null, SETTINGS_OPTION)
-    return
-  }
-
-  const suffix = isWindows ? 'Windows' : ipfsExists ? 'AlreadyExists' : 'NotExists'
-
-  // TODO: how to test modals?
-  const option = process.env.NODE_ENV === 'test' ? 0 : showDialog({
-    type: 'info',
-    title: i18n.t('cmdToolsDialog.title'),
-    message: i18n.t('cmdToolsDialog.message' + suffix),
-    buttons: [
-      i18n.t('yes'),
-      i18n.t('no')
-    ]
-  })
-
-  if (option === 0) {
-    // Trigger the toggler.
-    ipcMain.emit('config.toggle', null, SETTINGS_OPTION)
   } else {
+    // If not, don't make this verification next time. The user can manually
+    // toggle it in the Settings page.
     store.set(SETTINGS_OPTION, false)
   }
 }


### PR DESCRIPTION
Closes #933. If it's macOS or Windows **and** `ipfs` cannot be found in `PATH`, add it. Otherwise, the user can add manually on Settings. What about Linux? We always need permission to modify `path`/`/usr/local/bin` so checking the toggle manually option is the only way for now and the least intrusive.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>