### PR TITLE
chore: await delay in tests. Handle config write error.

### DIFF
--- a/src/utils/daemon.js
+++ b/src/utils/daemon.js
@@ -134,8 +134,14 @@ function checkCorsConfig (ipfsd) {
       if (allowedOrigins.some(origin => originsToRemove.includes(origin))) {
         const specificOrigins = allowedOrigins.filter(origin => !originsToRemove.includes(origin))
         config.API.HTTPHeaders['Access-Control-Allow-Origin'] = specificOrigins
-        writeConfigFile(ipfsd, config)
-        store.set('updatedCorsConfig', Date.now())
+        try {
+          writeConfigFile(ipfsd, config)
+          store.set('updatedCorsConfig', Date.now())
+        } catch (err) {
+          logger.error(`[daemon] checkCorsConfig: error writing config file: ${err.message || err}`)
+          // dont skip setting checkedCorsConfig so we try again next time time.
+          return
+        }
       }
     }
   }

--- a/test/spec.js
+++ b/test/spec.js
@@ -85,7 +85,7 @@ describe('Application launch', function () {
 
     const { app } = await startApp({ ipfsPath: repoPath })
     expect(app.isRunning()).to.be.true()
-    delay(5000)
+    await delay(5000)
     config = fs.readJsonSync(configPath)
     // ensure app has enabled cors checking
     expect(config.API.HTTPHeaders['Access-Control-Allow-Origin']).to.deep.equal([])
@@ -118,7 +118,7 @@ describe('Application launch', function () {
 
     const { app } = await startApp({ ipfsPath: repoPath })
     expect(app.isRunning()).to.be.true()
-    delay(5000)
+    await delay(5000)
     const config = fs.readJsonSync(configPath)
     // ensure app has enabled cors checking
     const specificOrigins = newOrigins.filter(origin => origin !== '*')


### PR DESCRIPTION
- the test occasionally fail in ci as we're not giving the app
time to update the config
- add a try/catch around the write conf, because you never know.

cherry-pick'd back from the 0.7.3-dev branch.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>