### PR TITLE
feat: restart daemon when connection changes

### DIFF
--- a/src/late/webui/connection-status.js
+++ b/src/late/webui/connection-status.js
@@ -1,0 +1,16 @@
+const { ipcRenderer } = require('electron')
+
+module.exports = function () {
+  let prevStatus = navigator.onLine
+
+  const handler = () => {
+    if (!prevStatus && navigator.onLine) {
+      ipcRenderer.send('restartIpfs')
+    }
+
+    prevStatus = navigator.onLine
+  }
+
+  window.addEventListener('online', handler)
+  window.addEventListener('offline', handler)
+}

--- a/src/late/webui/connection-status.js
+++ b/src/late/webui/connection-status.js
@@ -1,16 +1,11 @@
 const { ipcRenderer } = require('electron')
 
 module.exports = function () {
-  let prevStatus = navigator.onLine
-
   const handler = () => {
-    if (!prevStatus && navigator.onLine) {
-      ipcRenderer.send('restartIpfs')
-    }
-
-    prevStatus = navigator.onLine
+    ipcRenderer.send('online-status-changed', navigator.onLine)
   }
 
   window.addEventListener('online', handler)
   window.addEventListener('offline', handler)
+  handler()
 }

--- a/src/late/webui/preload.js
+++ b/src/late/webui/preload.js
@@ -1,10 +1,12 @@
 const { ipcRenderer } = require('electron')
 const screenshotHook = require('./screenshot')
+const connectionHook = require('./connection-status')
 
 const COUNTLY_KEY = '47fbb3db3426d2ae32b3b65fe40c564063d8b55d'
 const COUNTLY_KEY_TEST = '6b00e04fa5370b1ce361d2f24a09c74254eee382'
 
 screenshotHook()
+connectionHook()
 
 var originalSetItem = window.localStorage.setItem
 window.localStorage.setItem = function () {


### PR DESCRIPTION
Restarts the daemon when the connection gets changed. To test it, try turning off and on the WiFi or switching network.

Closes #930.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>