### PR TITLE
feat: add restart ipfs function

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmdFJsAzcuBKjd1A6pKeQkEbF2TJgArc6rHmYTPNLRot2A -p assets/webui/",
+    "build:webui:download": "npx ipfs-or-gateway -c QmTTMogvGu4NYNcGacauLEs3cLVPzHDQDE6rJGMRVxPgfw -p assets/webui/",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"

--- a/src/late/register-daemon.js
+++ b/src/late/register-daemon.js
@@ -109,6 +109,7 @@ export default async function (ctx) {
   ipcMain.on('startIpfs', startIpfs)
   ipcMain.on('stopIpfs', stopIpfs)
   ipcMain.on('restartIpfs', restartIpfs)
+  ipcMain.on('ipfsConfigChanged', restartIpfs)
   app.on('before-quit', stopIpfs)
 
   await startIpfs()

--- a/src/late/webui/preload.js
+++ b/src/late/webui/preload.js
@@ -39,8 +39,8 @@ window.ipfsDesktop = {
     ipcRenderer.send('config.toggle', setting)
   },
 
-  restartDaemon: () => {
-    ipcRenderer.send('restartIpfs')
+  configHasChanged: () => {
+    ipcRenderer.send('ipfsConfigChanged')
   },
 
   selectDirectory: () => {

--- a/src/late/webui/preload.js
+++ b/src/late/webui/preload.js
@@ -31,6 +31,10 @@ window.ipfsDesktop = {
 
   toggleSetting: (setting) => {
     ipcRenderer.send('config.toggle', setting)
+  },
+
+  restartDaemon: () => {
+    ipcRenderer.send('restartIpfs')
   }
 }
 


### PR DESCRIPTION
Adds `restartIpfs` function to `window.ipfsDesktop` object.

- See https://github.com/ipfs-shipyard/ipfs-webui/pull/1050

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>