### PR TITLE
feat: add shortcuts actions to menu

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -52,6 +52,8 @@
   "restartIpfsDesktop": "Restart IPFS Desktop",
   "openLogs": "Open logs",
   "anErrorHasOccurred": "An error has occurred",
+  "takeScreenshot": "Take Screenshot",
+  "downloadHash": "Download Hash",
   "polkitDialog": {
     "title": "Polkit not found",
     "message": "IPFS can't be added to /usr/local/bin/ without polkit agent."

--- a/src/late/take-screenshot.js
+++ b/src/late/take-screenshot.js
@@ -90,16 +90,19 @@ function handleScreenshot (ctx) {
   }
 }
 
-export default function (ctx) {
+export function takeScreenshot (ctx) {
   const { webui } = ctx
+  logger.info('[screenshot] taking screenshot')
+  webui.webContents.send('screenshot')
+}
 
+export default function (ctx) {
   const activate = (value, oldValue) => {
     if (value === oldValue) return
 
     if (value === true) {
       globalShortcut.register(shortcut, () => {
-        logger.info('[screenshot] taking screenshot')
-        webui.webContents.send('screenshot')
+        takeScreenshot(ctx)
       })
 
       logger.info('[screenshot] shortcut enabled')

--- a/src/late/tray.js
+++ b/src/late/tray.js
@@ -2,13 +2,17 @@ import { store, logger } from '../utils'
 import { Menu, Tray, shell, app, ipcMain } from 'electron'
 import i18n from 'i18next'
 import { STATUS } from './register-daemon'
+import { takeScreenshot } from './take-screenshot'
+import { downloadHash } from './download-hash'
 import path from 'path'
 import os from 'os'
 
 const isMac = os.platform() === 'darwin'
 const isLinux = os.platform() === 'linux'
 
-function buildMenu ({ checkForUpdates, launchWebUI }) {
+function buildMenu (ctx) {
+  const { checkForUpdates, launchWebUI } = ctx
+
   return Menu.buildFromTemplate([
     ...[
       ['ipfsIsStarting', 'yellow'],
@@ -53,6 +57,15 @@ function buildMenu ({ checkForUpdates, launchWebUI }) {
     {
       label: i18n.t('settings'),
       click: () => { launchWebUI('/settings') }
+    },
+    { type: 'separator' },
+    {
+      label: i18n.t('takeScreenshot'),
+      click: () => { takeScreenshot(ctx) }
+    },
+    {
+      label: i18n.t('downloadHash'),
+      click: () => { downloadHash(ctx) }
     },
     { type: 'separator' },
     {


### PR DESCRIPTION
Many users might not want to use the global shortcuts. If they don't enable them, they won't have access to the features. This way, the features are always accessible even when they don't have the global shortcuts enabled.

![image](https://user-images.githubusercontent.com/5447088/61207205-67793480-a6ec-11e9-96b0-670bb11e8ad8.png)

**Todo in a future PR:** shortcuts **only** when the menubar is open like Cmd+Q.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>