### PR TITLE
refactor: use functions instead of events

### DIFF
--- a/src/dialogs/ipfs-not-running.js
+++ b/src/dialogs/ipfs-not-running.js
@@ -1,10 +1,9 @@
 import dialog from './dialog'
 import i18n from 'i18next'
-import { ipcMain } from 'electron'
 import { STATUS } from '../late/register-daemon'
 import { logger } from '../utils'
 
-export default async function () {
+export default async function ({ startIpfs }) {
   logger.info('[ipfs-not-running] an action needs ipfs to be running')
 
   const option = dialog({
@@ -16,16 +15,9 @@ export default async function () {
     ]
   })
 
-  if (option === 0) {
-    return new Promise(resolve => {
-      ipcMain.on('ipfsd', (status) => {
-        if (status === STATUS.STARTING_STARTED) return
-        resolve(status === STATUS.STARTING_FINISHED)
-      })
-
-      ipcMain.emit('startIpfs')
-    })
+  if (option !== 0) {
+    return false
   }
 
-  return false
+  return (await startIpfs()) === STATUS.STARTING_FINISHED
 }

--- a/src/late/auto-updater.js
+++ b/src/late/auto-updater.js
@@ -4,7 +4,7 @@ import { logger, notify, quitAndInstall } from '../utils'
 
 let userRequested = false
 
-function setup () {
+function setup (ctx) {
   autoUpdater.autoDownload = false
 
   autoUpdater.on('error', (err) => {
@@ -47,7 +47,7 @@ function setup () {
       body: i18n.t('clickToInstall')
     }, () => {
       setImmediate(() => {
-        quitAndInstall()
+        quitAndInstall(ctx)
       })
     })
   })
@@ -73,7 +73,7 @@ export default async function (ctx) {
     return
   }
 
-  setup()
+  setup(ctx)
 
   await checkForUpdates()
   setInterval(checkForUpdates, 43200000) // every 12 hours

--- a/src/late/index.js
+++ b/src/late/index.js
@@ -19,7 +19,7 @@ export default async function (ctx) {
   await autoUpdater(ctx) // ctx.checkForUpdates
   await registerWebUI(ctx) // ctx.webui, ctx.launchWebUI
   await tray(ctx) // ctx.tray
-  await registerDaemon(ctx) // ctx.getIpfsd
+  await registerDaemon(ctx) // ctx.getIpfsd, startIpfs, stopIpfs, restartIpfs
   await addToIpfs(ctx)
   await autoLaunch(ctx)
   await downloadHash(ctx)

--- a/src/late/tray.js
+++ b/src/late/tray.js
@@ -11,8 +11,6 @@ import path from 'path'
 // or other OSes and must be registered globally. They still collide with global
 // accelerator. Please see ../utils/setup-global-shortcut.js for more info.
 function buildMenu (ctx) {
-  const { checkForUpdates, launchWebUI } = ctx
-
   return Menu.buildFromTemplate([
     ...[
       ['ipfsIsStarting', 'yellow'],
@@ -48,15 +46,15 @@ function buildMenu (ctx) {
     { type: 'separator' },
     {
       label: i18n.t('status'),
-      click: () => { launchWebUI('/') }
+      click: () => { ctx.launchWebUI('/') }
     },
     {
       label: i18n.t('files'),
-      click: () => { launchWebUI('/files') }
+      click: () => { ctx.launchWebUI('/files') }
     },
     {
       label: i18n.t('settings'),
-      click: () => { launchWebUI('/settings') }
+      click: () => { ctx.launchWebUI('/settings') }
     },
     { type: 'separator' },
     {
@@ -109,7 +107,7 @@ function buildMenu (ctx) {
         { type: 'separator' },
         {
           label: i18n.t('checkForUpdates'),
-          click: () => { checkForUpdates() }
+          click: () => { ctx.checkForUpdates() }
         },
         {
           label: i18n.t('viewOnGitHub'),

--- a/src/late/tray.js
+++ b/src/late/tray.js
@@ -30,19 +30,19 @@ function buildMenu (ctx) {
     {
       id: 'restartIpfs',
       label: i18n.t('restart'),
-      click: () => { ipcMain.emit('restartIpfs') },
+      click: () => { ctx.restartIpfs() },
       visible: false
     },
     {
       id: 'startIpfs',
       label: i18n.t('start'),
-      click: () => { ipcMain.emit('startIpfs') },
+      click: () => { ctx.startIpfs() },
       visible: false
     },
     {
       id: 'stopIpfs',
       label: i18n.t('stop'),
-      click: () => { ipcMain.emit('stopIpfs') },
+      click: () => { ctx.stopIpfs() },
       visible: false
     },
     { type: 'separator' },

--- a/src/utils/quit-and-install.js
+++ b/src/utils/quit-and-install.js
@@ -1,20 +1,18 @@
-import { ipcMain, app, BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { STATUS } from '../late/register-daemon'
 
 // adapted from https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
-export default function quitAndInstall () {
+export default async function quitAndInstall ({ stopIpfs }) {
   app.removeAllListeners('window-all-closed')
   const browserWindows = BrowserWindow.getAllWindows()
   browserWindows.forEach(function (browserWindow) {
     browserWindow.removeAllListeners('close')
   })
 
-  ipcMain.on('ipfsd', status => {
-    if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
-      autoUpdater.quitAndInstall(true, true)
-    }
-  })
+  const status = await stopIpfs()
 
-  ipcMain.emit('stopIpfs')
+  if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
+    autoUpdater.quitAndInstall(true, true)
+  }
 }


### PR DESCRIPTION
Use functions instead of events for **actions**.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>