### PR TITLE
chore: reduce ci issues with timeouts and retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode11
+
 before_script:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmXVMrPHtn6LHkaLudR7vRbsigGHf4hZ5bvsa5ttgExTrh -p assets/webui/",
+    "build:webui:download": "cross-env DEBUG=ipfs-or-gateway npx ipfs-or-gateway -c QmXVMrPHtn6LHkaLudR7vRbsigGHf4hZ5bvsa5ttgExTrh -p assets/webui/ --clean --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "cross-env DEBUG=ipfs-or-gateway npx ipfs-or-gateway -c QmXVMrPHtn6LHkaLudR7vRbsigGHf4hZ5bvsa5ttgExTrh -p assets/webui/ --clean --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c QmXVMrPHtn6LHkaLudR7vRbsigGHf4hZ5bvsa5ttgExTrh -p assets/webui/ --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmXVMrPHtn6LHkaLudR7vRbsigGHf4hZ5bvsa5ttgExTrh -p assets/webui/ --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c QmXVMrPHtn6LHkaLudR7vRbsigGHf4hZ5bvsa5ttgExTrh -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"

--- a/src/late/webui/index.js
+++ b/src/late/webui/index.js
@@ -45,6 +45,12 @@ const createWindow = () => {
     logger.info('[web ui] window hidden')
   })
 
+  app.on('before-quit', () => {
+    // Makes sure the app quits even though we prevent
+    // the closing of this window.
+    window.removeAllListeners('close')
+  })
+
   return window
 }
 
@@ -72,12 +78,6 @@ export default async function (ctx) {
       apiAddress = ipfsd.apiAddr
       window.loadURL(`webui://-?api=${apiAddress}&lng=${store.get('language')}#/`)
     }
-  })
-
-  app.on('before-quit', () => {
-    // Makes sure the app quits even though we prevent
-    // the closing of this window.
-    window.removeAllListeners('close')
   })
 
   ipcMain.on('config.get', () => {


### PR DESCRIPTION
Made some changes on `ipfs-or-gateway` which now supports multiple retries. It's configured for 3 retries (default) and 5 minutes of timeout (not default, but we know how the gateway can be at this time...).

Also updates the macOS version because it was failing since it was 'old'.

This **won't** solve everything. There might be timeouts anyway.

Ref.: #973 