### PR TITLE
fix: only quit after stopping daemon

### DIFF
--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -118,7 +118,14 @@ export default async function (ctx) {
   ctx.getIpfsd = getIpfsd
 
   ipcMain.on('ipfsConfigChanged', restartIpfs)
-  app.on('before-quit', stopIpfs)
+
+  app.on('before-quit', async e => {
+    if (ipfsd) {
+      e.preventDefault()
+      await stopIpfs()
+      app.quit()
+    }
+  })
 
   await startIpfs()
 


### PR DESCRIPTION
Hopefully fixes #974. Since we already have the timeout on `ipfsd.stop`, this won't add much time when quitting desktop.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>