### PR TITLE
fix: do not open webui when clicking the dock icon

### DIFF
--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -54,10 +54,6 @@ const createWindow = () => {
     window.removeAllListeners('close')
   })
 
-  app.on('activate', () => {
-    window.show()
-  })
-
   return window
 }
 


### PR DESCRIPTION
Prevents opening web ui when clicking the dock icon
because it is only active when there's an window open.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>