### PR TITLE
chore: add snapcraft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt update
       sudo apt install -y rpm
+      sudo snap install snapcraft --classic  
     fi
 
 script:


### PR DESCRIPTION
The latest beta version didn't build a `.snap` package because `snapcraft` wasn't installed. It was before. Probably an update on Travis Ubuntu version caused this.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>