### PR TITLE
feat: analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,6 +2541,15 @@
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2607,6 +2616,31 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "chardet": {
@@ -3007,6 +3041,15 @@
         }
       }
     },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -3081,6 +3124,11 @@
         "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
       }
+    },
+    "countly-sdk-nodejs": {
+      "version": "19.8.0",
+      "resolved": "https://registry.npmjs.org/countly-sdk-nodejs/-/countly-sdk-nodejs-19.8.0.tgz",
+      "integrity": "sha512-BPhQp3LL9zfS4lodAyFm/ziPYsdybth0IDuJdXBtXt8YiO2UKionRGE5JXQNfq5S4N2FrOfndQcKF7B9fMnZUA=="
     },
     "crc": {
       "version": "3.8.0",
@@ -3548,6 +3596,14 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "dot-prop": {
@@ -5969,6 +6025,15 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
     "hi-base32": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
@@ -6670,6 +6735,14 @@
         }
       }
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-npm": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
@@ -6770,6 +6843,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -7270,6 +7351,19 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "requires": {
+        "lower-case": "^1.1.2"
       }
     },
     "lowercase-keys": {
@@ -7817,6 +7911,14 @@
         "just-extend": "^4.0.2",
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "requires": {
+        "lower-case": "^1.1.1"
       }
     },
     "node-environment-flags": {
@@ -8370,6 +8472,14 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
       "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8396,12 +8506,29 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "requires": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true,
       "optional": true
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -9514,6 +9641,15 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -9818,6 +9954,14 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "snapdragon": {
@@ -10425,6 +10569,15 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -10561,6 +10714,15 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
       }
     },
     "tmp": {
@@ -10902,6 +11064,19 @@
         "latest-version": "^5.0.0",
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^3.0.0"
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "requires": {
+        "upper-case": "^1.1.1"
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "IPFS Native Application",
   "main": "out/index.js",
   "scripts": {
-    "start": "cross-env NODE_ENV=development electron -r @babel/register src/index.js",
+    "start": "cross-env NODE_ENV=development run-s build:babel start:electron",
+    "start:electron": "electron out/index.js",
     "lint": "standard",
     "test": "cross-env NODE_ENV=test mocha -r @babel/register",
     "postinstall": "run-s install-app-deps build:webui",
@@ -75,6 +76,8 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "auto-launch": "^5.0.5",
+    "change-case": "^3.1.0",
+    "countly-sdk-nodejs": "^19.8.0",
     "electron-serve": "^0.3.0",
     "electron-store": "^4.0.0",
     "electron-updater": "^4.1.2",

--- a/src/add-to-ipfs.js
+++ b/src/add-to-ipfs.js
@@ -38,10 +38,10 @@ export default async function ({ getIpfsd, launchWebUI }, file) {
     return
   }
 
-  logger.info(`[add to ipfs] started ${file}`)
+  logger.info(`[add to ipfs] started ${file}`, { withAnalytics: 'ADD_VIA_DESKTOP' })
   ipfsd.api.addFromFs(file, { recursive: true }, async (err, result) => {
     if (err) {
-      logger.error(err)
+      logger.error(`[add to ipfs] ${err.toString()}`)
       return notifyError({
         title: i18n.t('yourFilesCouldntBeAdded')
       })
@@ -52,7 +52,7 @@ export default async function ({ getIpfsd, launchWebUI }, file) {
       await copyFile(launchWebUI, ipfsd.api, hash, path, result.length > 1)
       logger.info(`[add to ipfs] completed ${file}`)
     } catch (err) {
-      logger.error(err)
+      logger.error(`[add to ipfs] ${err.toString()}`)
       notifyError({
         title: i18n.t('yourFilesCouldntBeAdded')
       })

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -21,15 +21,15 @@ export default function (ctx) {
     try {
       if (value === true) {
         if (!await autoLauncher.isEnabled()) await autoLauncher.enable()
-        logger.info('[launch on startup] enabled')
+        logger.info('[launch on startup] enabled', { withAnalytics: 'LAUNCH_STARTUP_ENABLED' })
       } else {
         if (await autoLauncher.isEnabled()) await autoLauncher.disable()
-        logger.info('[launch on startup] disabled')
+        logger.info('[launch on startup] disabled', { withAnalytics: 'LAUNCH_STARTUP_DISABLED' })
       }
 
       return true
     } catch (e) {
-      logger.error(e.stack)
+      logger.error(`[launch on startup] ${e.toString()}`)
       return false
     }
   }

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -18,7 +18,7 @@ function setup (ctx) {
       })
     }
 
-    logger.error(err)
+    logger.error(`[updater] ${err.toString()}`)
   })
 
   autoUpdater.on('update-available', async () => {
@@ -26,8 +26,8 @@ function setup (ctx) {
 
     try {
       await autoUpdater.downloadUpdate()
-    } catch (error) {
-      logger.error(error)
+    } catch (err) {
+      logger.error(`[updater] ${err.toString()}`)
     }
   })
 

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -10,3 +10,7 @@ export const VERSION = packageJson.version
 export const GO_IPFS_VERSION = packageJson['go-ipfs']
   ? packageJson['go-ipfs'].version.slice(1)
   : packageJson.dependencies['go-ipfs-dep']
+
+export const COUNTLY_KEY = process.env.NODE_ENV === 'development'
+  ? '6b00e04fa5370b1ce361d2f24a09c74254eee382'
+  : '47fbb3db3426d2ae32b3b65fe40c564063d8b55d'

--- a/src/common/logger.js
+++ b/src/common/logger.js
@@ -1,6 +1,8 @@
 import { createLogger, format, transports } from 'winston'
 import { join } from 'path'
 import { app } from 'electron'
+import { performance } from 'perf_hooks'
+import Countly from 'countly-sdk-nodejs'
 
 const { combine, splat, timestamp, printf } = format
 const logsPath = app.getPath('userData')
@@ -35,6 +37,47 @@ const logger = createLogger({
   ]
 })
 
-logger.info('[meta] logs can be found on %s', logsPath)
+logger.info(`[meta] logs can be found on ${logsPath}`)
 
-export default logger
+export default {
+  start: (msg, opts = {}) => {
+    const start = performance.now()
+    logger.info(`${msg} STARTED`)
+
+    return {
+      end: () => {
+        const seconds = (performance.now() - start) / 1000
+
+        if (opts.withAnalytics) {
+          Countly.add_event({
+            key: opts.withAnalytics,
+            count: 1,
+            dur: seconds
+          })
+        }
+
+        logger.info(`${msg} FINISHED ${seconds}s`)
+      },
+      fail: (err) => {
+        Countly.log_error(err)
+        logger.error(`${msg} ${err.toString()}`)
+      }
+    }
+  },
+
+  info: (msg, opts = {}) => {
+    if (opts.withAnalytics) {
+      Countly.add_event({
+        key: opts.withAnalytics,
+        count: 1
+      })
+    }
+
+    logger.info(msg)
+  },
+
+  error: (err) => {
+    Countly.log_error(err)
+    logger.error(err)
+  }
+}

--- a/src/create-toggler.js
+++ b/src/create-toggler.js
@@ -1,5 +1,7 @@
 import { ipcMain } from 'electron'
+import changeCase from 'change-case'
 import store from './common/store'
+import logger from './common/logger'
 
 export default function ({ webui }, settingsOption, activate) {
   ipcMain.on('config.toggle', async (_, opt) => {
@@ -14,6 +16,12 @@ export default function ({ webui }, settingsOption, activate) {
     if (await activate(newValue, oldValue)) {
       store.set(settingsOption, newValue)
       success = true
+
+      const action = newValue ? 'enabled' : 'disabled'
+
+      logger.info(`[${settingsOption}] ${action}`, {
+        withAnalytics: `${changeCase.constantCase(settingsOption)}_${changeCase.upperCase(action)}`
+      })
     }
 
     webui.webContents.send('config.changed', {

--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -43,7 +43,7 @@ async function cleanup (addr, path) {
     })
     logger.info('[daemon] cleanup: completed')
   } catch (e) {
-    logger.error('[daemon] ', e)
+    logger.error(`[daemon] ${e.toString()}`)
   }
 }
 

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -47,8 +47,8 @@ export default async function (ctx) {
       return
     }
 
+    const log = logger.start('[ipfsd] start daemon', { withAnalytics: 'DAEMON_START' })
     const config = store.get('ipfsConfig')
-    logger.info('[ipfsd] starting daemon')
     updateStatus(STATUS.STARTING_STARTED)
 
     if (config.path) {
@@ -70,10 +70,10 @@ export default async function (ctx) {
         writeIpfsPath(config.path)
       }
 
-      logger.info('[ipfsd] daemon started')
+      log.end()
       updateStatus(STATUS.STARTING_FINISHED)
     } catch (err) {
-      logger.error('[ipfsd] ', err)
+      log.fail(err)
       updateStatus(STATUS.STARTING_FAILED)
     }
   }
@@ -83,7 +83,7 @@ export default async function (ctx) {
       return
     }
 
-    logger.info('[ipfsd] stopping daemon')
+    const log = logger.start('[ipfsd] stop daemon', { withAnalytics: 'DAEMON_STOP' })
     updateStatus(STATUS.STOPPING_STARTED)
 
     if (!fs.pathExists(join(ipfsd.repoPath, 'config'))) {
@@ -97,10 +97,10 @@ export default async function (ctx) {
       // give ipfs 3s to stop. An unclean shutdown is preferable to making the
       // user wait, and taking longer prevents the update mechanism from working.
       await ipfsd.stop(180)
-      logger.info('[ipfsd] daemon stopped')
+      log.end()
       updateStatus(STATUS.STOPPING_FINISHED)
     } catch (err) {
-      logger.error('[ipfsd] ', err)
+      log.fail(err)
       updateStatus(STATUS.STOPPING_FAILED)
     } finally {
       ipfsd = null

--- a/src/download-hash.js
+++ b/src/download-hash.js
@@ -52,11 +52,11 @@ export async function downloadHash (ctx) {
   let files
 
   try {
-    logger.info(`[hash download] downloading ${text}: started`)
+    logger.info(`[hash download] downloading ${text}: started`, { withAnalytics: 'DOWNLOAD_HASH' })
     files = await ipfsd.api.get(text)
     logger.info(`[hash download] downloading ${text}: completed`)
   } catch (e) {
-    logger.error(e.stack)
+    logger.error(`[hash download] ${e.toString()}`)
 
     notifyError({
       title: i18n.t('cantDownloadHash'),
@@ -78,7 +78,7 @@ export async function downloadHash (ctx) {
       shell.showItemInFolder(path.join(dir, files[0].path))
     })
   } catch (e) {
-    logger.error(e.stack)
+    logger.error(`[hash download] ${e.toString()}`)
 
     notifyError({
       title: i18n.t('cantDownloadHash'),

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import setupArgvFilesHandler from './argv-files-handler'
 import setupAutoUpdater from './auto-updater'
 import setupTray from './tray'
 import setupIpfsOnPath from './ipfs-on-path'
+import setupAnalytics from './analytics'
 
 // Hide Dock
 if (app.dock) app.dock.hide()
@@ -53,6 +54,7 @@ async function run () {
   }
 
   try {
+    await setupAnalytics(ctx) // ctx.countlyDeviceId
     await setupI18n(ctx)
     await setupAppMenu(ctx)
 

--- a/src/move-repository-location.js
+++ b/src/move-repository-location.js
@@ -74,7 +74,7 @@ export default function ({ stopIpfs, startIpfs }) {
 
     config.path = newDir
     store.set('ipfsConfig', config)
-    logger.info('[move repository] configuration updated')
+    logger.info('[move repository] configuration updated', { withAnalytics: 'MOVE_REPOSITORY' })
 
     showDialog({
       title: i18n.t('moveRepositorySuccessDialog.title'),

--- a/src/npm-on-ipfs/package.js
+++ b/src/npm-on-ipfs/package.js
@@ -18,7 +18,7 @@ export async function update () {
       return
     }
   } catch (e) {
-    logger.error('[npm on ipfs] ipfs-npm: could not check if up to date %v', e)
+    logger.error(`[npm on ipfs] ipfs-npm: could not check if up to date ${e.toString()}`)
   }
 
   logger.info('[npm on ipfs] ipfs-npm: is out to date, will update')
@@ -31,7 +31,7 @@ export async function install () {
     logger.info('[npm on ipfs] ipfs-npm: installed globally')
     return true
   } catch (e) {
-    logger.error('[npm on ipfs] ', e)
+    logger.error(`[npm on ipfs] ${e.toString()}`)
     return false
   }
 }
@@ -42,7 +42,7 @@ export async function uninstall () {
     logger.info('[npm on ipfs] ipfs-npm: uninstalled globally')
     return true
   } catch (e) {
-    logger.error('[npm on ipfs] ', e)
+    logger.error(`[npm on ipfs] ${e.toString()}`)
     return false
   }
 }

--- a/src/setup-global-shortcut.js
+++ b/src/setup-global-shortcut.js
@@ -1,6 +1,5 @@
 import { globalShortcut, ipcMain } from 'electron'
 import createToggler from './create-toggler'
-import logger from './common/logger'
 import store from './common/store'
 import { IS_MAC } from './common/consts'
 
@@ -12,10 +11,8 @@ export default function (ctx, { settingsOption, accelerator, action }) {
 
     if (value === true) {
       globalShortcut.register(accelerator, action)
-      logger.info(`[${settingsOption}] shortcut enabled`)
     } else {
       globalShortcut.unregister(accelerator)
-      logger.info(`[${settingsOption}] shortcut disabled`)
     }
 
     return true

--- a/src/take-screenshot.js
+++ b/src/take-screenshot.js
@@ -37,7 +37,7 @@ async function onSucess (ipfs, launchWebUI, path, img) {
 }
 
 function onError (e) {
-  logger.error(e)
+  logger.error(`[screenshot] ${e.toString()}`)
 
   notifyError({
     title: i18n.t('couldNotTakeScreenshot'),
@@ -77,7 +77,7 @@ function handleScreenshot (ctx) {
         baseName += '.png'
       }
 
-      logger.info('[screenshot] started: writing screenshots to %s', baseName)
+      logger.info(`[screenshot] started: writing screenshots to ${baseName}`, { withAnalytics: 'SCREENSHOT_TAKEN' })
       let lastImage = null
 
       for (const { name, image } of output) {
@@ -87,7 +87,7 @@ function handleScreenshot (ctx) {
         lastImage = img
       }
 
-      logger.info('[screenshot] completed: writing screenshots to %s', baseName)
+      logger.info(`[screenshot] completed: writing screenshots to ${baseName}`)
       onSucess(ipfs, launchWebUI, baseName, lastImage)
     } catch (e) {
       onError(e)

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -75,7 +75,7 @@ export default async function (ctx) {
     }
   }
 
-  const url = new URL('/', 'http://localhost:3000/')
+  const url = new URL('/', 'webui://-')
   url.hash = '/'
   url.searchParams.set('lng', store.get('language'))
   url.searchParams.set('deviceId', ctx.countlyDeviceId)

--- a/src/webui/open-external.js
+++ b/src/webui/open-external.js
@@ -2,14 +2,14 @@ import { app, shell } from 'electron'
 
 export default function () {
   app.on('web-contents-created', (_, contents) => {
-    contents.on('will-navigate', (event, url) => {
+    /* contents.on('will-navigate', (event, url) => {
       const parsedUrl = new URL(url)
 
       if (parsedUrl.origin !== 'webui://-') {
         event.preventDefault()
         shell.openExternal(url)
       }
-    })
+    }) */
 
     contents.on('new-window', (event, url) => {
       event.preventDefault()

--- a/src/webui/open-external.js
+++ b/src/webui/open-external.js
@@ -2,14 +2,14 @@ import { app, shell } from 'electron'
 
 export default function () {
   app.on('web-contents-created', (_, contents) => {
-    /* contents.on('will-navigate', (event, url) => {
+    contents.on('will-navigate', (event, url) => {
       const parsedUrl = new URL(url)
 
       if (parsedUrl.origin !== 'webui://-') {
         event.preventDefault()
         shell.openExternal(url)
       }
-    }) */
+    })
 
     contents.on('new-window', (event, url) => {
       event.preventDefault()


### PR DESCRIPTION
- Closes #1063.
- Requires merging https://github.com/ipfs-shipyard/ipfs-webui/pull/1136.

This adds Analytics to IPFS Desktop using our Countly setup. This PR, in pair with the one on [IPFS Web UI repository](https://github.com/ipfs-shipyard/ipfs-webui/pull/1136), make a seamless integration between both Countly setups: we share the device id and the consents so we know on both sides what we can and can't send.

For this to work, I just created some wrappers around the logging functions to allow to send an event with it. If it has an event (`withAnalytics`), we log the event to Countly.

Also, created a `logger.start` function that allows us to measure, log and track time of certain actions, such as starting and stopping the daemon.