### PR TITLE
chore: do not upload to snap store

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -51,6 +51,8 @@ snap:
     - network
     - network-bind
     - removable-media
+  publish:
+    - github
 
 publish:
   - github


### PR DESCRIPTION
The [configuration](https://www.electron.build/configuration/snap) for `snap` says:

> snap target by default publishes to snap store (the app store for Linux). To force publishing to another providers, explicitly specify publish configuration for snap.

Perhaps this is the reason why publishing is failing on Linux since the logs show there is an error while publishing to snap store.

This was a change introduced in [Electron Builder v21.0.5](https://github.com/electron-userland/electron-builder/releases/tag/v21.0.15). They should have published it as a breaking change because... it is a breaking change.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>