### PR TITLE
fix: increased window draggable area

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c Qmbb7Wva8rDLfuuaAzeqr3vWZu2h6mthQTXbrJUAVoU4pM -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c QmZz7r1tmeBaaBRCVsxg7tTRVv1TxPHHGJ1BADxTA682w3 -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmNyMYhwJUS1cVvaWoVBhrW8KPj1qmie7rZcWo8f1Bvkhz -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c Qmbb7Wva8rDLfuuaAzeqr3vWZu2h6mthQTXbrJUAVoU4pM -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files",
     "build:binaries": "electron-builder --publish onTag"

--- a/src/webui/preload.js
+++ b/src/webui/preload.js
@@ -86,14 +86,3 @@ const apiAddress = urlParams.get('api')
 
 // Inject api address
 window.localStorage.setItem('ipfsApi', apiAddress)
-
-// Allow webui window to be dragged on mac
-document.addEventListener('DOMContentLoaded', function (event) {
-  var windowTopBar = document.createElement('div')
-  windowTopBar.style.width = '100%'
-  windowTopBar.style.height = '32px'
-  windowTopBar.style.position = 'absolute'
-  windowTopBar.style.top = windowTopBar.style.left = 0
-  windowTopBar.style.webkitAppRegion = 'drag'
-  document.body.appendChild(windowTopBar)
-})


### PR DESCRIPTION
Increases the draggable area of IPFS Desktop. The new draggable area is (anywhere in the light blue area can be clicked to drag and move the window around):

![image](https://user-images.githubusercontent.com/5447088/64115145-c2dbb080-cd86-11e9-9337-ce2ae68bde09.png)

It also fixes the issues when focusing the buttons/input.

- Needs https://github.com/ipfs-shipyard/ipfs-webui/pull/1138
- Fixes #1066

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>