### PR TITLE
refactor: replace requires by imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": [
-    "@babel/preset-env",
-    "@babel/preset-react"
+    "@babel/preset-env"
   ],
   "plugins": [
     "@babel/plugin-transform-runtime"

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,16 +158,6 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "@babel/helper-builder-react-jsx": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
-      "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.3.0",
-        "esutils": "^2.0.0"
-      }
-    },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
@@ -523,15 +513,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
-      "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
@@ -782,46 +763,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-react-display-name": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
-      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
-      "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-builder-react-jsx": "^7.3.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
-      "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
-      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      }
-    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
@@ -993,19 +934,6 @@
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
-      }
-    },
-    "@babel/preset-react": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
-      "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
     "@babel/register": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@babel/core": "^7.5.5",
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.5.5",
     "@svgr/cli": "^4.3.2",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "IPFS Native Application",
   "main": "out/index.js",
   "scripts": {
-    "start": "cross-env NODE_ENV=development electron -r @babel/register src/index.js",
+    "start": "cross-env NODE_ENV=development run-s build:babel start:electron",
+    "start:electron": "electron out/index.js",
     "lint": "standard",
     "test": "cross-env NODE_ENV=test mocha test/unit/**/*.spec.js -r @babel/register",
     "test:e2e": "xvfb-maybe cross-env NODE_ENV=test mocha test/e2e/**/*.e2e.js -r @babel/register",
@@ -17,7 +18,7 @@
     "build:webui": "run-s build:webui:*",
     "build:webui:download": "npx ipfs-or-gateway -c QmNyMYhwJUS1cVvaWoVBhrW8KPj1qmie7rZcWo8f1Bvkhz -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
-    "build:babel": "babel src --out-dir out --copy-files",
+    "build:babel": "babel src --out-dir out --copy-files --source-maps",
     "build:binaries": "electron-builder --publish onTag"
   },
   "pre-commit": [

--- a/src/app-menu.js
+++ b/src/app-menu.js
@@ -1,4 +1,4 @@
-import { app, Menu } from 'electron'
+import { app, Menu, shell } from 'electron'
 
 const template = [
   {
@@ -41,7 +41,9 @@ const template = [
     submenu: [
       {
         label: 'Learn More',
-        click () { require('electron').shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop') }
+        click () {
+          shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop')
+        }
       }
     ]
   }

--- a/src/exec-or-sudo.js
+++ b/src/exec-or-sudo.js
@@ -2,10 +2,11 @@ import i18n from 'i18next'
 import util from 'util'
 import sudo from 'sudo-prompt'
 import { dialog, app } from 'electron'
+import childProcess from 'child_process'
 import { recoverableErrorDialog } from './dialogs'
 import logger from './common/logger'
 
-const execFile = util.promisify(require('child_process').execFile)
+const execFile = util.promisify(childProcess.execFile)
 
 const env = {
   noSudo: {

--- a/src/ipfs-on-path/scripts/backup.js
+++ b/src/ipfs-on-path/scripts/backup.js
@@ -1,5 +1,5 @@
-const fs = require('fs-extra')
-const { join } = require('path')
+import fs from 'fs-extra'
+import { join } from 'path'
 
 function checkErr (err) {
   // NOTE: there is a bug where copySync will throw if the inode
@@ -10,7 +10,7 @@ function checkErr (err) {
   }
 }
 
-function backup (userData, original) {
+export function backup (userData, original) {
   const bin = original.split('/').pop()
   const backup = join(userData, bin + '.bak')
 
@@ -23,7 +23,7 @@ function backup (userData, original) {
   console.log(`${original} copied to ${backup}`)
 }
 
-function revert (userData, bin, dst) {
+export function revert (userData, bin, dst) {
   const backup = join(userData, bin + '.bak')
 
   try {
@@ -51,9 +51,4 @@ function revert (userData, bin, dst) {
   } catch (_) {
     // Failed to remove the backup. Suprising, but not worth bothering the user about.
   }
-}
-
-module.exports = {
-  backup,
-  revert
 }

--- a/src/ipfs-on-path/scripts/consts.js
+++ b/src/ipfs-on-path/scripts/consts.js
@@ -1,6 +1,4 @@
-const { join } = require('path')
+import { join } from 'path'
 
-module.exports = {
-  SOURCE_SCRIPT: join(__dirname, 'ipfs.sh').replace('app.asar', 'app.asar.unpacked'),
-  DEST_SCRIPT: '/usr/local/bin/ipfs'
-}
+export const SOURCE_SCRIPT = join(__dirname, 'ipfs.sh').replace('app.asar', 'app.asar.unpacked')
+export const DEST_SCRIPT = '/usr/local/bin/ipfs'

--- a/src/ipfs-on-path/scripts/install.js
+++ b/src/ipfs-on-path/scripts/install.js
@@ -1,8 +1,8 @@
-const fs = require('fs-extra')
-const which = require('which')
-const { backup } = require('./backup')
-const argv = require('yargs').argv
-const { SOURCE_SCRIPT, DEST_SCRIPT } = require('./consts')
+import fs from 'fs-extra'
+import which from 'which'
+import { backup } from './backup'
+import { argv } from 'yargs'
+import { SOURCE_SCRIPT, DEST_SCRIPT } from './consts'
 
 let exists = false
 

--- a/src/ipfs-on-path/scripts/uninstall.js
+++ b/src/ipfs-on-path/scripts/uninstall.js
@@ -1,5 +1,5 @@
-const { DEST_SCRIPT } = require('./consts')
-const { revert } = require('./backup')
-const argv = require('yargs').argv
+import { DEST_SCRIPT } from './consts'
+import { revert } from './backup'
+import { argv } from 'yargs'
 
 revert(argv.data, 'ipfs', DEST_SCRIPT)

--- a/src/npm-on-ipfs/package.js
+++ b/src/npm-on-ipfs/package.js
@@ -1,8 +1,9 @@
 import util from 'util'
 import logger from '../common/logger'
 import { IS_WIN } from '../common/consts'
+import childProcess from 'child_process'
 
-const execFile = util.promisify(require('child_process').execFile)
+const execFile = util.promisify(childProcess.execFile)
 const npmBin = IS_WIN ? 'npm.cmd' : 'npm'
 
 export async function update () {

--- a/src/webui/connection-status.js
+++ b/src/webui/connection-status.js
@@ -1,6 +1,6 @@
-const { ipcRenderer } = require('electron')
+import { ipcRenderer } from 'electron'
 
-module.exports = function () {
+export default function () {
   const handler = () => {
     ipcRenderer.send('online-status-changed', navigator.onLine)
   }

--- a/src/webui/preload.js
+++ b/src/webui/preload.js
@@ -1,11 +1,11 @@
-const toPull = require('stream-to-pull-stream')
-const { ipcRenderer, remote } = require('electron')
-const readdir = require('recursive-readdir')
-const fs = require('fs-extra')
-const path = require('path')
-const screenshotHook = require('./screenshot')
-const connectionHook = require('./connection-status')
-const pkg = require('../../package.json')
+import toPull from 'stream-to-pull-stream'
+import { ipcRenderer, remote } from 'electron'
+import readdir from 'recursive-readdir'
+import fs from 'fs-extra'
+import path from 'path'
+import screenshotHook from './screenshot'
+import connectionHook from './connection-status'
+import pkg from '../../package.json'
 
 const COUNTLY_KEY = '47fbb3db3426d2ae32b3b65fe40c564063d8b55d'
 const COUNTLY_KEY_TEST = '6b00e04fa5370b1ce361d2f24a09c74254eee382'

--- a/src/webui/screenshot.js
+++ b/src/webui/screenshot.js
@@ -1,4 +1,4 @@
-const { ipcRenderer, desktopCapturer } = require('electron')
+import { ipcRenderer, desktopCapturer } from 'electron'
 
 async function streamHandler (format, stream) {
   const track = stream.getVideoTracks()[0]
@@ -50,7 +50,7 @@ async function screenshot (format) {
   return output
 }
 
-module.exports = function () {
+export default function () {
   ipcRenderer.on('screenshot', async () => {
     const out = await screenshot()
     ipcRenderer.send('screenshot', out)

--- a/test/e2e/launch.e2e.js
+++ b/test/e2e/launch.e2e.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
-const Application = require('spectron').Application
-const electronPath = require('electron') // Require Electron from the binaries included in node_modules.
-const path = require('path')
-const fs = require('fs-extra')
-const tmp = require('tmp')
-const delay = require('delay')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
+import { Application } from 'spectron'
+import electronPath from 'electron' // Require Electron from the binaries included in node_modules.
+import path from 'path'
+import fs from 'fs-extra'
+import tmp from 'tmp'
+import delay from 'delay'
+import chai from 'chai'
+import dirtyChai from 'dirty-chai'
+import { makeRepository } from './utils/ipfsd'
+
 const expect = chai.expect
 chai.use(dirtyChai)
-
-const { makeRepository } = require('./utils/ipfsd')
 
 // To print the app logs, add the following to your test:
 //

--- a/test/e2e/utils/include.js
+++ b/test/e2e/utils/include.js
@@ -1,3 +1,5 @@
+// This file is included before anything else on the tested app.
+// It is not compiled beforehand so it needs to use requires.
 require('@babel/register')
 
 const tmp = require('tmp')

--- a/test/e2e/utils/ipfsd.js
+++ b/test/e2e/utils/ipfsd.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
-const tmp = require('tmp')
-const IPFSFactory = require('ipfsd-ctl')
+import tmp from 'tmp'
+import IPFSFactory from 'ipfsd-ctl'
 
 async function makeRepository () {
   const dir = tmp.dirSync({ unsafeCleanup: true })


### PR DESCRIPTION
1. Refactors the remaining `require`s into `import`s.
2. Builds source maps when Babel is run.
3. Starts Electron after running Babel.
4. Removes babel `preset-react`.

In the future I should look into a way to reload Electron when the files are changed.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>