### PR TITLE
fix: move IPFS_PATH to ~/.ipfs-desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ assets/webui
 *.nupkg
 *.bak
 assets/build/snap-hooks
-IPFS_PATH

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -139,8 +139,8 @@ export default async function (ctx) {
 }
 
 function writeIpfsPath (path) {
-  fs.writeFileSync(
-    join(__dirname, '../ipfs-on-path/scripts/IPFS_PATH')
+  fs.outputFileSync(
+    join(app.getPath('home'), './.ipfs-desktop/IPFS_PATH')
       .replace('app.asar', 'app.asar.unpacked'),
     path
   )

--- a/src/ipfs-on-path/scripts/bin-win/ipfs.cmd
+++ b/src/ipfs-on-path/scripts/bin-win/ipfs.cmd
@@ -1,7 +1,7 @@
 @echo off
 
-if exist "%~dp0\..\IPFS_PATH" (
-  SET /P IPFS_PATH=<"%~dp0\..\IPFS_PATH"
+if exist "%USERPROFILE%\.ipfs-desktop\IPFS_PATH" (
+  SET /P IPFS_PATH=<"%USERPROFILE%\.ipfs-desktop\IPFS_PATH"
 )
 
 "%~dp0\..\..\..\..\node_modules\go-ipfs-dep\go-ipfs\ipfs.exe" %*

--- a/src/ipfs-on-path/scripts/ipfs.sh
+++ b/src/ipfs-on-path/scripts/ipfs.sh
@@ -2,8 +2,8 @@
 
 dir="$(dirname "$(test -L "$0" && readlink "$0" || echo "$0")")"
 
-if [ -f "$dir/IPFS_PATH" ]; then
-  export IPFS_PATH="$(cat "$dir/IPFS_PATH")"
+if [ -f ~/.ipfs-desktop/IPFS_PATH ]; then
+  export IPFS_PATH="$(cat ~/.ipfs-desktop/IPFS_PATH)"
 fi
 
 # Get the full path of the app directory (resolving the symlink if needed)


### PR DESCRIPTION
This fixes the issue caused by having IPFS_PATH in the same directory as the app code. That would fail in multiple circumstances:

1. When the app was updated, IPFS_PATH would get deleted.
2. macOS gatekeeper paths randomization for security purposes creates a read-only directory for the app files when the app isn't executed from secure locations (such as ~/Applications) and it would make it fail.

Closes #1077.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>