### PR TITLE
fix: allow multiple gateway and api ports

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -109,6 +109,6 @@
   "multipleBusyPortsDialog": {
     "title": "Ports are busy",
     "message": "Cannot bind to one or more of the API or Gateway addresses because the ports are busy.",
-    "action": "I will fix the configuration"
+    "action": "Open configuration file"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -105,5 +105,10 @@
     "title": "Port is busy",
     "message": "The port { port } is not available. Do you want to use { alt } instead?",
     "action": "Use port { alt } instead"
+  },
+  "multipleBusyPortsDialog": {
+    "title": "Ports are busy",
+    "message": "Some of the API or Gateway addresses cannot be binded to because ports are busy.",
+    "action": "I will fix the configuration"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -108,7 +108,7 @@
   },
   "multipleBusyPortsDialog": {
     "title": "Ports are busy",
-    "message": "Some of the API or Gateway addresses cannot be binded to because ports are busy.",
+    "message": "Cannot bind to one or more of the API or Gateway addresses because the ports are busy.",
     "action": "I will fix the configuration"
   }
 }

--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -169,9 +169,16 @@ const parseCfgMultiaddr = (addr) => (addr.includes('/http')
 )
 
 async function checkPortsArray (addrs) {
+  addrs = addrs.filter(Boolean)
+
   for (const addr of addrs) {
     const ma = parseCfgMultiaddr(addr)
     const port = parseInt(ma.nodeAddress().port, 10)
+
+    if (port === 0) {
+      continue
+    }
+
     const isDaemon = await checkIfAddrIsDaemon(ma.nodeAddress())
 
     if (isDaemon) {
@@ -203,15 +210,6 @@ async function checkPorts (ipfsd) {
 
   if (apiIsArr || gatewayIsArr) {
     logger.info('[daemon] custom configuration with array of API or Gateway addrs')
-
-    let addrs = apiIsArr
-      ? config.Addresses.API
-      : [config.Addresses.API]
-
-    addrs = gatewayIsArr
-      ? addrs.concat(config.Addresses.Gateway)
-      : addrs.concat([config.Addresses.Gateway])
-
     return checkPortsArray([].concat(config.Addresses.API, config.Addresses.Gateway))
   }
 

--- a/src/daemon/daemon.js
+++ b/src/daemon/daemon.js
@@ -212,7 +212,7 @@ async function checkPorts (ipfsd) {
       ? addrs.concat(config.Addresses.Gateway)
       : addrs.concat([config.Addresses.Gateway])
 
-    return checkPortsArray(addrs)
+    return checkPortsArray([].concat(config.Addresses.API, config.Addresses.Gateway))
   }
 
   const configApiMa = parseCfgMultiaddr(config.Addresses.API)

--- a/test/e2e/launch.e2e.js
+++ b/test/e2e/launch.e2e.js
@@ -136,4 +136,32 @@ describe('Application launch', function () {
     const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
     expect(app.isRunning()).to.be.true()
   })
+
+  it('starts with multiple api addresses', async function () {
+    const { ipfsd } = await makeRepository()
+    const { repoPath } = ipfsd
+    await ipfsd.stop()
+    const configPath = path.join(repoPath, 'config')
+    const config = fs.readJsonSync(configPath)
+
+    config.Addresses.API = ['/ip4/127.0.0.1/tcp/5001', '/ip4/127.0.0.1/tcp/5002']
+
+    fs.writeFile(configPath, config)
+    const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
+    expect(app.isRunning()).to.be.true()
+  })
+
+  it('starts with multiple gateway addresses', async function () {
+    const { ipfsd } = await makeRepository()
+    const { repoPath } = ipfsd
+    await ipfsd.stop()
+    const configPath = path.join(repoPath, 'config')
+    const config = fs.readJsonSync(configPath)
+
+    config.Addresses.Gateway = ['/ip4/127.0.0.1/tcp/8080', '/ip4/127.0.0.1/tcp/8081']
+
+    fs.writeFile(configPath, config)
+    const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
+    expect(app.isRunning()).to.be.true()
+  })
 })


### PR DESCRIPTION
Fixes #1091

On the case there is an array of API or Gateway addresses and one or more of them collide with already busy ports, we show this message:

![image](https://user-images.githubusercontent.com/5447088/64429575-3b57af80-d0ae-11e9-90fc-254015c9a2d5.png)

Users that have multiple addresses for API/Gateway already changed the configuration on their own and know how to solve this kind of issues.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>