### PR TITLE
chore: force exit mocha after tests complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:electron": "electron out/index.js",
     "lint": "standard",
     "test": "cross-env NODE_ENV=test mocha test/unit/**/*.spec.js -r @babel/register",
-    "test:e2e": "xvfb-maybe cross-env NODE_ENV=test mocha test/e2e/**/*.e2e.js -r @babel/register",
+    "test:e2e": "xvfb-maybe cross-env NODE_ENV=test mocha test/e2e/**/*.e2e.js -r @babel/register --exit",
     "postinstall": "run-s install-app-deps build:webui",
     "install-app-deps": "electron-builder install-app-deps",
     "clean:webui": "shx rm -rf assets/webui/",


### PR DESCRIPTION
This is a workaround for now before finding why sometimes mocha does not exit even after tests are done, which makes CI fail.

Probably some IPFS cleaning up that takes too long or gets stale.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>