### PR TITLE
fix: fail silently 'IPFS' on path auto action

### DIFF
--- a/src/ipfs-on-path/index.js
+++ b/src/ipfs-on-path/index.js
@@ -51,7 +51,11 @@ async function runWindows (script, failSilently) {
     ], {}, err => {
       if (err) {
         logger.error(`[ipfs on path] ${err.toString()}`)
-        if (!failSilently) recoverableErrorDialog(err)
+
+        if (!failSilently) {
+          recoverableErrorDialog(err)
+        }
+
         return resolve(false)
       }
 
@@ -69,6 +73,7 @@ async function run (script, trySudo = true, failSilently = false) {
   return execOrSudo({
     script: join(__dirname, `./scripts/${script}.js`),
     scope: 'ipfs on path',
-    trySudo
+    trySudo,
+    failSilently
   })
 }

--- a/src/ipfs-on-path/index.js
+++ b/src/ipfs-on-path/index.js
@@ -38,11 +38,11 @@ async function firstTime () {
   // to sudo so the user doesn't get annoying prompts when running IPFS Desktop
   // for the first time. Sets the option according to the success or failure of the
   // procedure.
-  const res = await run('install', false, true)
+  const res = await run('install', { trySudo: false, failSilently: true })
   store.set(CONFIG_KEY, res)
 }
 
-async function runWindows (script, failSilently) {
+async function runWindows (script, { failSilently }) {
   return new Promise(resolve => {
     execFile('powershell.exe', [
       '-nop', '-exec', 'bypass',
@@ -65,9 +65,9 @@ async function runWindows (script, failSilently) {
   })
 }
 
-async function run (script, trySudo = true, failSilently = false) {
+async function run (script, { trySudo = true, failSilently = false }) {
   if (IS_WIN) {
-    return runWindows(script, failSilently)
+    return runWindows(script, { failSilently })
   }
 
   return execOrSudo({

--- a/src/ipfs-on-path/index.js
+++ b/src/ipfs-on-path/index.js
@@ -38,11 +38,11 @@ async function firstTime () {
   // to sudo so the user doesn't get annoying prompts when running IPFS Desktop
   // for the first time. Sets the option according to the success or failure of the
   // procedure.
-  const res = await run('install', false)
+  const res = await run('install', false, true)
   store.set(CONFIG_KEY, res)
 }
 
-async function runWindows (script) {
+async function runWindows (script, failSilently) {
   return new Promise(resolve => {
     execFile('powershell.exe', [
       '-nop', '-exec', 'bypass',
@@ -51,7 +51,7 @@ async function runWindows (script) {
     ], {}, err => {
       if (err) {
         logger.error(`[ipfs on path] ${err.toString()}`)
-        recoverableErrorDialog(err)
+        if (!failSilently) recoverableErrorDialog(err)
         return resolve(false)
       }
 
@@ -61,9 +61,9 @@ async function runWindows (script) {
   })
 }
 
-async function run (script, trySudo = true) {
+async function run (script, trySudo = true, failSilently = false) {
   if (IS_WIN) {
-    return runWindows(script)
+    return runWindows(script, failSilently)
   }
 
   return execOrSudo({


### PR DESCRIPTION
This makes adding `ipfs` to PATH fail silently when it wasn't the user triggering the action, i.e., it fails silently only when try to add the binary to the PATH the first time we launch IPFS Desktop.