### PR TITLE
fix: undefined on function argument

### DIFF
--- a/src/ipfs-on-path/index.js
+++ b/src/ipfs-on-path/index.js
@@ -65,7 +65,7 @@ async function runWindows (script, { failSilently }) {
   })
 }
 
-async function run (script, { trySudo = true, failSilently = false }) {
+async function run (script, { trySudo = true, failSilently = false } = {}) {
   if (IS_WIN) {
     return runWindows(script, { failSilently })
   }


### PR DESCRIPTION
Fixes #1113. There was no default value so it would fail.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>