### PR TITLE
fix: open external urls

### DIFF
--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -59,6 +59,8 @@ const createWindow = () => {
 }
 
 export default async function (ctx) {
+  openExternal()
+
   const window = createWindow(ctx)
   let apiAddress = null
 
@@ -101,8 +103,6 @@ export default async function (ctx) {
     delete details.requestHeaders.Origin
     callback({ cancel: false, requestHeaders: details.requestHeaders }) // eslint-disable-line
   })
-
-  openExternal()
 
   return new Promise(resolve => {
     window.once('ready-to-show', () => {


### PR DESCRIPTION
Fix #1100.

`openExternal` sets up an event listener and it was being set up after the web ui window.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>