### PR TITLE
fix: call log.fail instead of logger.error

### DIFF
--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -73,7 +73,7 @@ export default async function (ctx) {
       log.end()
       updateStatus(STATUS.STARTING_FINISHED)
     } catch (err) {
-      logger.error(`[ipfsd] ${err.toString()}`)
+      log.fail(err)
       updateStatus(STATUS.STARTING_FAILED)
     }
   }


### PR DESCRIPTION
License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>