### PR TITLE
feat: v8 compile code cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11250,8 +11250,7 @@
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
-      "dev": true
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "recursive-readdir": "^2.2.2",
     "stream-to-pull-stream": "^1.7.3",
     "sudo-prompt": "^9.0.0",
+    "v8-compile-cache": "^2.1.0",
     "which": "^2.0.1",
     "winston": "^3.2.1",
     "yargs": "^14.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'v8-compile-cache'
 import { app, dialog } from 'electron'
 import fixPath from 'fix-path'
 import { criticalErrorDialog } from './dialogs'


### PR DESCRIPTION
Add [`v8-compile-cache`](https://github.com/zertosh/v8-compile-cache) for better performance. Many of the suggestions online to improve Electron's performance is by adding this compile cache. I thought about giving it a try. It actually seems a bit faster after the first launch here.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>