### PR TITLE
feat: web ui 2.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmPURAjo3oneGH53ovt68UZEBvsc8nNmEhQZEpsVEQUMZE -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c QmeSXt32frzhvewLKwA1dePTSjkTfGVwTh55ZcsJxrCSnk -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files --source-maps",
     "build:binaries": "electron-builder --publish onTag"


### PR DESCRIPTION
Relevant release notes can be found on [v2.5.5](https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.5.5).