### PR TITLE
fix: use blank page when window isn't active

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c QmeSXt32frzhvewLKwA1dePTSjkTfGVwTh55ZcsJxrCSnk -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c QmRLGrLEjy1TsUBEyoPqSwdZwPjA48CjeZzJ7PD73nWyz4 -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:babel": "babel src --out-dir out --copy-files --source-maps",
     "build:binaries": "electron-builder --publish onTag"

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -82,7 +82,7 @@ export default async function (ctx) {
   }
 
   const url = new URL('/', 'webui://-')
-  url.hash = '/'
+  url.hash = '/blank'
   url.searchParams.set('deviceId', ctx.countlyDeviceId)
 
   function updateLanguage () {

--- a/src/webui/preload.js
+++ b/src/webui/preload.js
@@ -21,8 +21,20 @@ window.localStorage.setItem = function () {
   originalSetItem.apply(this, arguments)
 }
 
+let previousHash = null
+
 ipcRenderer.on('updatedPage', (_, url) => {
+  previousHash = url
   window.location.hash = url
+})
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    previousHash = window.location.hash
+    window.location.hash = '/blank'
+  } else {
+    window.location.hash = previousHash
+  }
 })
 
 window.ipfsDesktop = {


### PR DESCRIPTION
This addresses #1196 by changing to a blank page whenever the window is not visible. For this, we use the Page Visibility API.

Requires https://github.com/ipfs-shipyard/ipfs-webui/pull/1259.

This reduced **significantly** the CPU usage on my end.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>