### PR TITLE
feat: set icon and category in Linux .desktop file

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,7 +34,8 @@ nsis:
 linux:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}
   executableName: ipfs-desktop
-  category: Utility
+  icon: ipfs-desktop
+  category: Network;FileTransfer;P2P
   synopsis: A desktop client for IPFS
   maintainer: henrique@protocol.ai
   target:


### PR DESCRIPTION
This patch gives IPFS Desktop the correct icon and puts it in the correct category in the desktop applications menu.