### PR TITLE
feat: improve auto launch at login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1980,6 +1980,13 @@
         "path-is-absolute": "^1.0.0",
         "untildify": "^3.0.2",
         "winreg": "1.2.4"
+      },
+      "dependencies": {
+        "untildify": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+          "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+        }
       }
     },
     "aws-sign2": {
@@ -11071,9 +11078,9 @@
       }
     },
     "untildify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "unzip-stream": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "recursive-readdir": "^2.2.2",
     "stream-to-pull-stream": "^1.7.3",
     "sudo-prompt": "^9.0.0",
+    "untildify": "^4.0.0",
     "v8-compile-cache": "^2.1.0",
     "which": "^2.0.1",
     "winston": "^3.2.1",

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -18,9 +18,9 @@ function isSupported () {
 // Disable the old auto launch mechanism.
 // TODO: remove on 0.10.0.
 async function disableOldLogin () {
-  const autoLauncher = new AutoLaunch({ name: 'IPFS Desktop' })
-
   try {
+    const autoLauncher = new AutoLaunch({ name: 'IPFS Desktop' })
+
     if (await autoLauncher.isEnabled()) {
       await autoLauncher.disable()
       logger.error('[launch on startup] old mechanism disabled')

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -42,8 +42,8 @@ async function enable () {
   const desktop = `[Desktop Entry]
 Type=Application
 Version=1.0
-Name="IPFS Desktop"
-Comment="IPFS Desktop Startup Script"
+Name=IPFS Desktop
+Comment=IPFS Desktop Startup Script
 Exec="${process.execPath}"
 StartupNotify=false
 Terminal=false`

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -15,13 +15,24 @@ function isSupported () {
   return plat === 'linux' || plat === 'win32' || plat === 'darwin'
 }
 
+// Disable the old auto launch mechanism.
+// TODO: remove on 0.10.0.
+async function disableOldLogin () {
+  const autoLauncher = new AutoLaunch({ name: 'IPFS Desktop' })
+
+  try {
+    if (await autoLauncher.isEnabled()) {
+      await autoLauncher.disable()
+      logger.error('[launch on startup] old mechanism disabled')
+    }
+  } catch (_) {
+    // ignore...
+  }
+}
+
 function getDesktopFile () {
   return path.join(untildify('~/.config/autostart/'), 'ipfs-desktop.desktop')
 }
-
-const autoLauncher = new AutoLaunch({
-  name: 'IPFS Desktop'
-})
 
 async function enable () {
   if (app.setLoginItemSettings) {
@@ -49,9 +60,7 @@ async function disable () {
 }
 
 export default async function (ctx) {
-  // Disable the old auto launch mechanism.
-  // TODO: remove on 0.10.0.
-  if (await autoLauncher.isEnabled()) await autoLauncher.disable()
+  await disableOldLogin()
 
   const activate = async (value, oldValue) => {
     if (process.env.NODE_ENV === 'development') {

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -37,6 +37,7 @@ function getDesktopFile () {
 async function enable () {
   if (app.setLoginItemSettings) {
     app.setLoginItemSettings({ openAtLogin: true })
+    return
   }
 
   const desktop = `[Desktop Entry]
@@ -54,6 +55,7 @@ Terminal=false`
 async function disable () {
   if (app.setLoginItemSettings) {
     app.setLoginItemSettings({ openAtLogin: false })
+    return
   }
 
   await fs.remove(getDesktopFile())

--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -1,29 +1,77 @@
 import AutoLaunch from 'auto-launch'
+import { app } from 'electron'
+import os from 'os'
+import path from 'path'
+import fs from 'fs-extra'
+import untildify from 'untildify'
 import createToggler from './create-toggler'
 import logger from './common/logger'
 import store from './common/store'
 
 const CONFIG_KEY = 'autoLaunch'
 
+function isSupported () {
+  const plat = os.platform()
+  return plat === 'linux' || plat === 'win32' || plat === 'darwin'
+}
+
+function getDesktopFile () {
+  return path.join(untildify('~/.config/autostart/'), 'ipfs-desktop.desktop')
+}
+
 const autoLauncher = new AutoLaunch({
   name: 'IPFS Desktop'
 })
 
-export default function (ctx) {
+async function enable () {
+  if (app.setLoginItemSettings) {
+    app.setLoginItemSettings({ openAtLogin: true })
+  }
+
+  const desktop = `[Desktop Entry]
+Type=Application
+Version=1.0
+Name="IPFS Desktop"
+Comment="IPFS Desktop Startup Script"
+Exec="${process.execPath}"
+StartupNotify=false
+Terminal=false`
+
+  await fs.outputFile(getDesktopFile(), desktop)
+}
+
+async function disable () {
+  if (app.setLoginItemSettings) {
+    app.setLoginItemSettings({ openAtLogin: false })
+  }
+
+  await fs.remove(getDesktopFile())
+}
+
+export default async function (ctx) {
+  // Disable the old auto launch mechanism.
+  // TODO: remove on 0.10.0.
+  if (await autoLauncher.isEnabled()) await autoLauncher.disable()
+
   const activate = async (value, oldValue) => {
     if (process.env.NODE_ENV === 'development') {
       logger.info('[launch on startup] unavailable during development')
       return
     }
 
+    if (!isSupported()) {
+      logger.info('[launch on startup] not supported on this platform')
+      return false
+    }
+
     if (value === oldValue) return
 
     try {
       if (value === true) {
-        if (!await autoLauncher.isEnabled()) await autoLauncher.enable()
+        await enable()
         logger.info('[launch on startup] enabled')
       } else {
-        if (await autoLauncher.isEnabled()) await autoLauncher.disable()
+        await disable()
         logger.info('[launch on startup] disabled')
       }
 


### PR DESCRIPTION
Auto Login was working... kinda of. According to the reports by @alexhenrie, auto launch on startup was not working on login since our installation path has a space on it and the [package](https://github.com/Teamwork/node-auto-launch/issues/99) we're using is not escaping that properly.

Unfortunately, [`node-auto-launch`](https://github.com/Teamwork/node-auto-launch/issues/99) hasn't been updated since 2017 and since then, Electron got its own capabilities to add login items for Windows and macOS so we can use that feature.

This changes the following:

- Stops using `node-auto-launch` for managing our launch at login state. It is still a required dependency so we can remove previous entries created by it. It will be removed on 0.10.0.
- Starts using `app.setLoginItemSettings` to manage login state on Windows and macOS.
- For Linux, we create a `.desktop` entry similar to the one `node-auto-launch` did, but with the execution path properly escaped.

@alexhenrie could you try this out on your end, please?