### PR TITLE
feat: give the IPFS startup entry an icon

### DIFF
--- a/src/auto-launch.js
+++ b/src/auto-launch.js
@@ -47,6 +47,7 @@ Version=1.0
 Name=IPFS Desktop
 Comment=IPFS Desktop Startup Script
 Exec="${process.execPath}"
+Icon=ipfs-desktop
 StartupNotify=false
 Terminal=false`
 


### PR DESCRIPTION
There's no reason for the IPFS Desktop file in `~/.config/autostart` to look ugly.