### PR TITLE
feat: copy link to clipboard when adding to ipfs

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -22,14 +22,8 @@
   "shareableLinkCopied": "Shareable link copied to the clipboard. Click here to view the screenshot.",
   "couldNotTakeScreenshot": "Could not take screenshot",
   "errorwhileTakingScreenshot": "An error occurred while taking the screenshot.",
-  "yourFilesCouldntBeAdded": "Your files couldn't be added.",
-  "folderAdded": "Folder added",
-  "folderAddedToIpfsClickToView": "Folder { name } added to IPFS. Click to view the folder.",
-  "fileAdded": "File added",
-  "fileAddedToIpfsClickToView": "File { name } added to IPFS. Click to view the file.",
   "clickToOpenLogs": "Click here to open the logs.",
   "ipfsNotRunning": "IPFS is not running",
-  "desktopIsStartedButDaemonOffline": "IPFS Desktop is started but the daemon is turned off.",
   "cantDownloadHash": "Could not download hash",
   "invalidHashClipboard": "The hash on the clipboard is not valid.",
   "errorWhileDownloadingHash": "An error occurred while getting the hash.",
@@ -51,7 +45,6 @@
   "reportTheError": "Report the error",
   "restartIpfsDesktop": "Restart IPFS Desktop",
   "openLogs": "Open logs",
-  "anErrorHasOccurred": "An error has occurred",
   "takeScreenshot": "Take Screenshot",
   "downloadHash": "Download Hash",
   "moveRepositoryLocation": "Move Repository Location",
@@ -110,5 +103,17 @@
     "title": "Ports are busy",
     "message": "Cannot bind to one or more of the API or Gateway addresses because the ports are busy.",
     "action": "Open configuration file"
+  },
+  "itemsAddedNotification": {
+    "title": "Items added",
+    "message": "{ count } items added to your node. A shareable link was copied to your clipboard. Click here to see your files."
+  },
+  "itemAddedNotification": {
+    "title": "Item added",
+    "message": "Item added to your node. A shareable link was copied to your clipboard. Click here to see your file."
+  },
+  "itemsFailedNotification": {
+    "title": "Failed to add items",
+    "message": "Could not add your items to your node."
   }
 }

--- a/src/add-to-ipfs.js
+++ b/src/add-to-ipfs.js
@@ -25,8 +25,9 @@ async function copyFile (ipfs, hash, name) {
   return ipfs.files.cp(`/ipfs/${hash}`, `/${name}`)
 }
 
-async function makeObject (ipfs, results) {
+async function makeShareableObject (ipfs, results) {
   if (results.length === 1) {
+    // If it's just one object, we link it directly.
     return results[0]
   }
 
@@ -43,7 +44,7 @@ async function makeObject (ipfs, results) {
   return { hash: baseCID, path: '' }
 }
 
-function sendNotification (failures, successes, launch, cidAndPath) {
+function sendNotification (failures, successes, launch, path) {
   let link, title, body, fn
 
   if (failures.length === 0) {
@@ -51,7 +52,7 @@ function sendNotification (failures, successes, launch, cidAndPath) {
     fn = notify
 
     if (successes.length === 1) {
-      link = `/files/${cidAndPath.path}`
+      link = `/files/${path}`
       title = i18n.t('itemAddedNotification.title')
       body = i18n.t('itemAddedNotification.message')
     } else {
@@ -100,10 +101,9 @@ export default async function ({ getIpfsd, launchWebUI }, files) {
     log.end()
   }
 
-  const cidAndPath = await makeObject(ipfsd.api, successes)
-  sendNotification(failures, successes, launchWebUI, cidAndPath)
+  const { hash, path } = await makeShareableObject(ipfsd.api, successes)
+  sendNotification(failures, successes, launchWebUI, path)
 
-  // TODO: change to share.ipfs.io once that's fixed
-  const url = `https://ipfs.io/ipfs/${cidAndPath.hash}`
+  const url = `https://ipfs.io/ipfs/${hash}`
   clipboard.writeText(url)
 }

--- a/src/argv-files-handler.js
+++ b/src/argv-files-handler.js
@@ -4,6 +4,7 @@ import addToIpfs from './add-to-ipfs'
 export async function argvHandler (argv, ctx) {
   let handled = false
 
+  const files = []
   for (const arg of argv.slice(1)) {
     if (!arg.startsWith('--add')) {
       continue
@@ -12,9 +13,13 @@ export async function argvHandler (argv, ctx) {
     const filename = arg.slice(6)
 
     if (await fs.pathExists(filename)) {
-      await addToIpfs(ctx, filename)
-      handled = true
+      files.push(filename)
     }
+  }
+
+  if (files.length > 0) {
+    await addToIpfs(ctx, files)
+    handled = true
   }
 
   return handled

--- a/src/tray.js
+++ b/src/tray.js
@@ -150,10 +150,7 @@ export default function (ctx) {
 
   // macOS tray drop files
   tray.on('drop-files', async (_, files) => {
-    for (const file of files) {
-      await addToIpfs(ctx, file)
-    }
-
+    await addToIpfs(ctx, files)
     ctx.launchWebUI('/files', { focus: false })
   })
 


### PR DESCRIPTION
With this PR, we get back the feature of copying a shareable link to the clipboard when adding files to our node via the IPFS icon that sits on the menubar on macOS or to the shortcut of the app on Windows.

In addition, I cleaned up the locale messages, removing some that are not used anymore and updating the ones we have for this notification in particular. I will create a separate PR organizing the translation file a bit more.

We now add all files at once and give only **one notification**. If the user drops multiple files, we create an object linking to all of them, which is used for the shareable link and when clicking on the notification.

Closes #1218.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>