### PR TITLE
fix: ignore net:: errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ app.on('will-finish-launching', () => {
 function handleError (err) {
   // Ignore network errors that might happen during the
   // execution.
-  if (err.toString().includes('net::')) {
+  if (err.stack.includes('net::')) {
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,12 @@ app.on('will-finish-launching', () => {
 })
 
 function handleError (err) {
+  // Ignore network errors that might happen during the
+  // execution.
+  if (err.toString().includes('net::')) {
+    return
+  }
+
   logger.error(err)
   criticalErrorDialog(err)
 }


### PR DESCRIPTION
This aims to fix #1267. I don't know how to reproduce the error so I'm not sure if this is going to fix it. Those errors never have stack trace so it's hard to understand them. However, I believe this might fix it because it just ignores errors with `net::` on it generated by unhandled rejections and exceptions.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>