### PR TITLE
fix: start with off icon

### DIFF
--- a/src/tray.js
+++ b/src/tray.js
@@ -147,7 +147,7 @@ function icon (color) {
 
 export default function (ctx) {
   logger.info('[tray] starting')
-  const tray = new Tray(icon(on))
+  const tray = new Tray(icon(off))
   let menu = null
   let status = {}
 


### PR DESCRIPTION
This just fixes some weird change I made on https://github.com/ipfs-shipyard/ipfs-desktop/blob/48ef20ec6eba628fd5b75bc2e84e6f5b95e084a1/src/tray.js: start with the offline icon.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>