### PR TITLE
chore: go-ipfs v0.4.23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - xvfb
 
 node_js:
-  - 12.1.0
+  - 12.14.1
 
 os:
   - linux
@@ -16,7 +16,7 @@ before_script:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt update
-      sudo apt install -y rpm
+      sudo apt install -y rpm snapd
       sudo snap install snapcraft --classic
       echo $SNAP_TOKEN | snapcraft login --with -
     fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1497,12 +1497,19 @@
       }
     },
     "@hapi/bounce": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.1.tgz",
-      "integrity": "sha512-/ecFQTRBom2MEbjMHvKKE6FZ/e1gYK72CeUIFzz++dKK1kYJ0KbRJ72mXroWoTT2hIv+8H0ua/eOkO0+hRdHcw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
+      "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "^8.3.1"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+        }
       }
     },
     "@hapi/bourne": {
@@ -1511,23 +1518,42 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/call": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
-      "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.2.tgz",
+      "integrity": "sha512-10XyXbpo0fAXmOf/Q4BCgsQrrTZuwa6/FcSnuKqD06sZz5yMCmJTD8VpmolEjEfwJqXtQBZHj9g/IYcmHk3nxQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.2.tgz",
-      "integrity": "sha512-a4KejaKqDOMdwo/PIYoAaObVMmkfkG3RS85kPqNTTURjWnIV1+rrZ938f6RCz5EbrroKbuNC0bcvAt7lAD5LNg==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
+      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x",
+        "@hapi/joi": "16.x.x",
         "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/catbox-memory": {
@@ -1548,9 +1574,9 @@
       }
     },
     "@hapi/cryptiles": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
-      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
+      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
       "requires": {
         "@hapi/boom": "7.x.x"
       }
@@ -1560,10 +1586,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
       "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
     },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
     "@hapi/hapi": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.2.tgz",
-      "integrity": "sha512-UJogSyMPe4VFfzjQW5v2ixLvTLZLSfPs1XV/DRnAl2znzsGCaNJI+tgNxjM9lszOjEEkMfxLgoXZadk9exnIxw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
+      "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
       "requires": {
         "@hapi/accept": "3.x.x",
         "@hapi/ammo": "3.x.x",
@@ -1586,13 +1617,32 @@
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.1.tgz",
-      "integrity": "sha512-uaEyC4AtGCGKt/LLBbdDQxJP1bFAbxiot6n/fwa4kyo6w8ULpXXCh8FxLlJ5mC06lqbAxQv45JyozIB6P4Dsig==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
+      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/hoek": {
@@ -1601,12 +1651,13 @@
       "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
     },
     "@hapi/iron": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.1.tgz",
-      "integrity": "sha512-QYfm6nofZ19pIxm8LR0lsANBabrdxqe0vUYKKI+0w9VdCetoove+dxfbLfduVDM72kh/RNOQG6E5/xyI826PcA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
+      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
       "requires": {
         "@hapi/b64": "4.x.x",
         "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
         "@hapi/hoek": "8.x.x"
       }
@@ -1652,22 +1703,65 @@
         "@hapi/nigel": "3.x.x"
       }
     },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
     "@hapi/podium": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.1.tgz",
-      "integrity": "sha512-WbwYr5nK+GIrCdgEbN8R7Mh7z+j9AgntOLQ/YQdeLtBp+uScVmW9FoycKdNS5uweO74xwICr28Ob0DU74a2zmg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
+      "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
       "requires": {
         "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/shot": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.1.tgz",
-      "integrity": "sha512-TrsqCyaq24XcdvD0bSi26hjwyQQy5q/nzpasbPNgPLoGnxW3sCWE7ws3ba6dd6Atb8TEh9QBD7mBQDCrMMz2Ig==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
+      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
       "requires": {
         "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/somever": {
@@ -1680,9 +1774,9 @@
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.1.tgz",
-      "integrity": "sha512-tMfS6B8QdrqTaKRUhHv6Ur7oPK6kcEZcnnvBK4IuaPZA9ma5UsyprTXkzbiB0V+0E56dMg3RabO1SABeZkzy6g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
+      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bounce": "1.x.x",
@@ -1690,13 +1784,32 @@
         "@hapi/cryptiles": "4.x.x",
         "@hapi/hoek": "8.x.x",
         "@hapi/iron": "5.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+          "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+        },
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
-      "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.2.tgz",
+      "integrity": "sha512-G1kqD1E2QdxpvpL26WieIyo3z0qCa/sAGSa2TJI/PYPWCR9rL0rqFvhWY774xPZ4uK1PV3TIaJcx8AruAvxclg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
@@ -1729,9 +1842,9 @@
       }
     },
     "@hapi/wreck": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.2.tgz",
-      "integrity": "sha512-D/7sGmx3XxxkaMWHZDKTMai8rIEfIgE+DnoZeKfmxhKGgvIpMu1f8BBmLADbdniccGer79w74IWWdXleNrT1Rw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
@@ -3056,9 +3169,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "chromium-pickle-js": {
       "version": "0.2.0",
@@ -6562,9 +6675,9 @@
       }
     },
     "go-ipfs-dep": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.22.tgz",
-      "integrity": "sha512-e1hPrnMzuowL8kF0xx3SorSTzmy2fHvKvb2X4lzGBv67M2ClgpFrGQ9MaaiocFNiMopwrWRNcxpHEaLWU8KPKA==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.23.tgz",
+      "integrity": "sha512-D2thGjsteCIiV6CkPejlQzRPFVURwOsRYh3Sb0eX0xBFcw8TTv1X7J7Urkp8jiXomqD11OsoAZtoZs0w35xwLw==",
       "requires": {
         "go-platform": "^1.0.0",
         "gunzip-maybe": "^1.4.1",
@@ -11233,9 +11346,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "stream-to-pull-stream": {
       "version": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "yargs": "^15.0.2"
   },
   "go-ipfs": {
-    "version": "v0.4.22"
+    "version": "v0.4.23-rc1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "fix-path": "^2.1.0",
     "fs-extra": "^8.1.0",
     "get-port": "^5.0.0",
-    "go-ipfs-dep": "0.4.22",
+    "go-ipfs-dep": "0.4.23",
     "i18next": "^19.0.2",
     "i18next-electron-language-detector": "0.0.10",
     "i18next-icu": "^1.1.2",
@@ -103,6 +103,6 @@
     "yargs": "^15.0.2"
   },
   "go-ipfs": {
-    "version": "v0.4.23-rc1"
+    "version": "v0.4.23"
   }
 }

--- a/test/e2e/launch.e2e.js
+++ b/test/e2e/launch.e2e.js
@@ -30,7 +30,6 @@ describe('Application launch', function () {
   afterEach(async function () {
     if (app && app.isRunning()) {
       await app.stop()
-      await delay(3000)
     }
   })
 
@@ -133,7 +132,7 @@ describe('Application launch', function () {
     const configPath = path.join(repoPath, 'config')
     const apiPath = path.join(repoPath, 'api')
     const config = fs.readJsonSync(configPath)
-    fs.writeFile(apiPath, config.Addresses.API)
+    await fs.writeFile(apiPath, config.Addresses.API)
     const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
     expect(app.isRunning()).to.be.true()
   })
@@ -147,7 +146,7 @@ describe('Application launch', function () {
 
     config.Addresses.API = [`/ip4/127.0.0.1/tcp/${await getPort()}`, `/ip4/127.0.0.1/tcp/${await getPort()}`]
 
-    fs.writeFile(configPath, config)
+    await fs.writeFile(configPath, config)
     const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
     expect(app.isRunning()).to.be.true()
   })
@@ -161,7 +160,7 @@ describe('Application launch', function () {
 
     config.Addresses.Gateway = [`/ip4/127.0.0.1/tcp/${await getPort()}`, `/ip4/127.0.0.1/tcp/${await getPort()}`]
 
-    fs.writeFile(configPath, config)
+    await fs.writeFile(configPath, config)
     const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
     expect(app.isRunning()).to.be.true()
   })

--- a/test/e2e/launch.e2e.js
+++ b/test/e2e/launch.e2e.js
@@ -23,7 +23,7 @@ function createTmpDir () {
 }
 
 describe('Application launch', function () {
-  this.timeout(60000)
+  this.timeout(process.env.CI ? 180000 : 60000)
   let app = null
 
   afterEach(async function () {

--- a/test/e2e/launch.e2e.js
+++ b/test/e2e/launch.e2e.js
@@ -9,6 +9,7 @@ import delay from 'delay'
 import chai from 'chai'
 import dirtyChai from 'dirty-chai'
 import { makeRepository } from './utils/ipfsd'
+import getPort from 'get-port'
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -144,7 +145,7 @@ describe('Application launch', function () {
     const configPath = path.join(repoPath, 'config')
     const config = fs.readJsonSync(configPath)
 
-    config.Addresses.API = ['/ip4/127.0.0.1/tcp/5001', '/ip4/127.0.0.1/tcp/5002']
+    config.Addresses.API = [`/ip4/127.0.0.1/tcp/${await getPort()}`, `/ip4/127.0.0.1/tcp/${await getPort()}`]
 
     fs.writeFile(configPath, config)
     const { app } = await startApp({ ipfsPath: ipfsd.repoPath })
@@ -158,7 +159,7 @@ describe('Application launch', function () {
     const configPath = path.join(repoPath, 'config')
     const config = fs.readJsonSync(configPath)
 
-    config.Addresses.Gateway = ['/ip4/127.0.0.1/tcp/8080', '/ip4/127.0.0.1/tcp/8081']
+    config.Addresses.Gateway = [`/ip4/127.0.0.1/tcp/${await getPort()}`, `/ip4/127.0.0.1/tcp/${await getPort()}`]
 
     fs.writeFile(configPath, config)
     const { app } = await startApp({ ipfsPath: ipfsd.repoPath })


### PR DESCRIPTION
- [x] Smoke-test v0.4.23-rc1  
- [x] Fix snap build on Linux
- [x] Switch CI to the current Node LTS
- [x] Switch this PR to v0.4.23 when ships (https://github.com/ipfs/go-ipfs/issues/6837)
- [ ] Fix E2E tests on CI (Mac)