### PR TITLE
fix: start on login

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s clean:webui build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c Qmexhq2sBHnXQbvyP2GfUdbnY7HCagH2Mw5vUNSBn2nxip -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c bafybeidatpz2hli6fgu3zul5woi27ujesdf5o5a7bu622qj6ugharciwjq -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:binaries": "electron-builder --publish onTag"
   },

--- a/src/create-toggler.js
+++ b/src/create-toggler.js
@@ -1,4 +1,5 @@
 const { ipcMain } = require('electron')
+const os = require('os')
 const store = require('./common/store')
 const logger = require('./common/logger')
 
@@ -23,6 +24,7 @@ module.exports = function ({ webui }, settingsOption, activate) {
     webui.webContents.send('config.changed', {
       config: store.store,
       changed: settingsOption,
+      platform: os.platform(),
       success
     })
   })

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -2,6 +2,7 @@ const { screen, BrowserWindow, ipcMain, app, session } = require('electron')
 const { join } = require('path')
 const { URL } = require('url')
 const serve = require('electron-serve')
+const os = require('os')
 const openExternal = require('./open-external')
 const logger = require('../common/logger')
 const store = require('../common/store')
@@ -101,7 +102,10 @@ module.exports = async function (ctx) {
   })
 
   ipcMain.on('config.get', () => {
-    window.webContents.send('config.changed', { config: store.store })
+    window.webContents.send('config.changed', {
+      platform: os.platform(),
+      config: store.store
+    })
   })
 
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {

--- a/test/unit/create-toggler.spec.js
+++ b/test/unit/create-toggler.spec.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon')
 const chai = require('chai')
 const { expect } = chai
+const os = require('os')
 const dirtyChai = require('dirty-chai')
 const mockElectron = require('./mocks/electron')
 const mockStore = require('./mocks/store')
@@ -43,6 +44,7 @@ describe('Create toggler', () => {
       expect(args[0]).to.equal('config.changed')
       expect(args[1]).to.deep.equal({
         changed: 'OPT',
+        platform: os.platform(),
         config: {
           OPT: true
         },
@@ -68,6 +70,7 @@ describe('Create toggler', () => {
       expect(args[0]).to.equal('config.changed')
       expect(args[1]).to.deep.equal({
         changed: 'OPT',
+        platform: os.platform(),
         config: {},
         success: false
       })
@@ -93,6 +96,7 @@ describe('Create toggler', () => {
       expect(args[0]).to.equal('config.changed')
       expect(args[1]).to.deep.equal({
         changed: 'OPT',
+        platform: os.platform(),
         config: {
           OPT: false
         },
@@ -120,6 +124,7 @@ describe('Create toggler', () => {
       expect(args[0]).to.equal('config.changed')
       expect(args[1]).to.deep.equal({
         changed: 'OPT',
+        platform: os.platform(),
         config: {
           OPT: true
         },


### PR DESCRIPTION
- Closes #1290.
- Should be tested with https://github.com/ipfs-shipyard/ipfs-webui/pull/1381.

With this change, we send the result from `os.platform()` from the main process to the renderer process so we can actual know which platform we're using.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>