### PR TITLE
docs: clarified release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ Other languages are periodically pulled from [Transifex](https://www.transifex.c
 ## Releasing
 
 - (Optional) Create a new [Draft Release](https://github.com/ipfs-shipyard/ipfs-desktop/releases).
-- Bump the version in `package.json`.
-- Create a tag with the same version.
-- `git push && git push --tags`
+- Bump the version in `package.json`
+- Create a tag with the same version: `git tag vA.B.C`
+- Publish local changes and the tag to GitHub repo: `git push && git push origin vA.B.C`
 - Wait for the CI to upload the binaries to the draft release (a new one will be created if you haven't drafted one).
 - The `latest.yml, latest-mac.yml, latest-linux.yml` files on the release are used by the app to determine when an app update is available. Once a release is published, users should recieve the app update. See: https://www.electron.build/auto-update.
 - Update [Homebrew Cask](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@
 
 **Download the latest release**
 
-- Mac - [ipfs-desktop-0.10.2.dmg](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2.dmg)
-- Windows - [ipfs-desktop-setup-0.10.2.exe](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-setup-0.10.2.exe)
-- Linux - [ipfs-desktop-0.10.2-linux-x86_64.AppImage](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.AppImage)
-
-or see the [install](#install) section for more options.
+- Mac - [IPFS-Desktop-0.10.3.dmg](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/IPFS-Desktop-0.10.3.dmg) or `brew cask install ipfs`
+- Windows - [IPFS-Desktop-Setup-0.10.3.exe](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/IPFS-Desktop-Setup-0.10.3.exe) or `choco install ipfs-desktop`
+- Linux - see the [install](#install) section for available options
 
 ![IPFS Desktop](https://user-images.githubusercontent.com/157609/55424318-426b1680-5580-11e9-93ec-ec261879367f.jpg)
 
@@ -19,7 +17,7 @@ or see the [install](#install) section for more options.
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![](https://david-dm.org/ipfs-shipyard/ipfs-desktop.svg?style=flat-square)](https://david-dm.org/ipfs-shipyard/ipfs-desktop)
 [![total download count](https://img.shields.io/github/downloads/ipfs-shipyard/ipfs-desktop/total.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases)
-[![latest release download count](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/total.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.10.2)
+[![latest release download count](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/total.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/tag/v0.10.3)
 
 IPFS Desktop allows you to run your IPFS Node on your machine without having to bother with command line tools. With it, you have the power of [Web UI](https://github.com/ipfs-shipyard/ipfs-webui) on tip of your hands plus a handful of shortcuts you can find on settings.
 
@@ -68,24 +66,25 @@ Download the latest release of IPFS Desktop for your OS, below.
 
 | Platform | Download link | Download count
 |---------:|---------------|---------------
-| **Windows**  | [ipfs-desktop-setup-0.10.2.exe](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-setup-0.10.2.exe) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/ipfs-desktop-setup-0.10.2.exe.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-setup-0.10.2.exe)
-| **Mac**    | [ipfs-desktop-0.10.2.dmg](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2.dmg) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/ipfs-desktop-0.10.2.dmg.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2.dmg)
+| **Windows**  | [IPFS-Desktop-Setup-0.10.3.exe](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/IPFS-Desktop-Setup-0.10.3.exe) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/IPFS-Desktop-Setup-0.10.3.exe.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/IPFS-Desktop-Setup-0.10.3.exe)
+| **Mac**    | [IPFS-Desktop-0.10.3.dmg](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/IPFS-Desktop-0.10.3.dmg) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/IPFS-Desktop-0.10.3.dmg.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/IPFS-Desktop-0.10.3.dmg)
 
-We build out multiple installers for **Linux**
+We provide multiple _experimental_ installers for **Linux** and **FreeBSD**:
 
 | Package | Download link | Download count
 |---------:|---------------|---------------
-| AppImage | [ipfs-desktop-0.10.2-linux-x86_64.AppImage](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.AppImage) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.AppImage.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.AppImage)
-| tar | [ipfs-desktop-0.10.2-linux-x64.tar.xz](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x64.tar.xz) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/ipfs-desktop-0.10.2-linux-x64.tar.xz.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x64.tar.xz)
-| deb | [ipfs-desktop-0.10.2-linux-amd64.deb](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-amd64.deb) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/ipfs-desktop-0.10.2-linux-amd64.deb.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-amd64.deb)
-| rpm | [ipfs-desktop-0.10.2-linux-x86_64.rpm](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.rpm) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.rpm.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.2/ipfs-desktop-0.10.2-linux-x86_64.rpm)
+| tar | [ipfs-desktop-0.10.3-linux-x64.tar.xz](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x64.tar.xz) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/ipfs-desktop-0.10.3-linux-x64.tar.xz.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x64.tar.xz)
+| deb | [ipfs-desktop-0.10.3-linux-amd64.deb](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-amd64.deb) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/ipfs-desktop-0.10.3-linux-amd64.deb.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-amd64.deb)
+| rpm | [ipfs-desktop-0.10.3-linux-x86_64.rpm](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x86_64.rpm) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/ipfs-desktop-0.10.3-linux-x86_64.rpm.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x86_64.rpm)
+| AppImage | [ipfs-desktop-0.10.3-linux-x86_64.AppImage](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x86_64.AppImage) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/ipfs-desktop-0.10.3-linux-x86_64.AppImage.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x86_64.AppImage)
+| freebsd | [ipfs-desktop-0.10.3-linux-x64.freebsd](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x64.freebsd) | [![](https://img.shields.io/github/downloads-pre/ipfs-shipyard/ipfs-desktop/v0.10.3/ipfs-desktop-0.10.3-linux-x64.freebsd.svg?style=flat-square)](https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.10.3/ipfs-desktop-0.10.3-linux-x64.freebsd)
 
 Or you can use your favorite package manager:
 
 - **Homebrew** - `brew cask install ipfs`
 - **Chocolatey** - `choco install ipfs-desktop`
 - **Snap** - `snap install ipfs-desktop`
-- **AUR** - [`ipfs-desktop` package](https://aur.archlinux.org/packages/ipfs-desktop/) maintained by @alexhenrie
+- **AUR** - [`ipfs-desktop` package](https://aur.archlinux.org/packages/ipfs-desktop/) maintained by [@alexhenrie](https://github.com/alexhenrie)
 
 > Using package managers? Please head to [our package managers page](https://github.com/ipfs-shipyard/ipfs-desktop/issues/691) and help us add support for yours!
 
@@ -101,7 +100,7 @@ Then the follow the steps below to clone the source code, install the dependenci
 ```bash
 git clone https://github.com/ipfs-shipyard/ipfs-desktop.git
 cd ipfs-desktop
-npm install
+npm ci
 npm start
 ```
 


### PR DESCRIPTION
- [x] Improved instructions push only the new tag, instead of all local tags.
- [x] Updated links for 0.10.3 (#1338)