### PR TITLE
feat: notify when the update is available

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -34,6 +34,7 @@
   "clickToInstall": "Click here to restart and install the newer version of IPFS Desktop.",
   "updateNotAvailable": "Update not available",
   "runningLatestVersion": "You seem to be running the latest version.",
+  "updateIsBeingDownloaded": "There is an update available and it is being downloaded.",
   "couldNotCheckForUpdates": "Could not check for updates",
   "pleaseCheckInternet": "Please check your Internet connection.",
   "checkForUpdates": "Check for Updates...",

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -6,23 +6,32 @@ import { notify } from '../common/notify'
 
 let userRequested = false
 
+function notifyIfRequested (...opts) {
+  if (userRequested) {
+    userRequested = false
+    notify(...opts)
+  }
+}
+
 function setup (ctx) {
   autoUpdater.autoDownload = false
 
   autoUpdater.on('error', (err) => {
-    if (userRequested) {
-      userRequested = false
-      notify({
-        title: i18n.t('couldNotCheckForUpdates'),
-        body: i18n.t('pleaseCheckInternet')
-      })
-    }
+    notifyIfRequested({
+      title: i18n.t('couldNotCheckForUpdates'),
+      body: i18n.t('pleaseCheckInternet')
+    })
 
     logger.error(`[updater] ${err.toString()}`)
   })
 
   autoUpdater.on('update-available', async () => {
     logger.info('[updater] update available. download started')
+
+    notifyIfRequested({
+      title: i18n.t('updateAvailable'),
+      body: i18n.t('updateIsBeingDownloaded')
+    })
 
     try {
       await autoUpdater.downloadUpdate()
@@ -32,13 +41,10 @@ function setup (ctx) {
   })
 
   autoUpdater.on('update-not-available', async () => {
-    if (userRequested) {
-      userRequested = false
-      notify({
-        title: i18n.t('updateNotAvailable'),
-        body: i18n.t('runningLatestVersion')
-      })
-    }
+    notifyIfRequested({
+      title: i18n.t('updateNotAvailable'),
+      body: i18n.t('runningLatestVersion')
+    })
   })
 
   autoUpdater.on('update-downloaded', () => {


### PR DESCRIPTION
Adds a notification when the user clicks 'Check for Updates...' and there is an update available. Right now, we either show the notification when there is **no update available** or we **finished downloading the update**, which may take some time.

Not sure if this addresses #1378 but I'm pretty sure it will improve UX anyways.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>