### PR TITLE
fix: call stopIpfs on ctx

### DIFF
--- a/src/auto-updater/quit-and-install.js
+++ b/src/auto-updater/quit-and-install.js
@@ -3,14 +3,14 @@ import { autoUpdater } from 'electron-updater'
 import { STATUS } from '../daemon'
 
 // adapted from https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
-export default async function quitAndInstall ({ stopIpfs }) {
+export default async function quitAndInstall (ctx) {
   app.removeAllListeners('window-all-closed')
   const browserWindows = BrowserWindow.getAllWindows()
   browserWindows.forEach(function (browserWindow) {
     browserWindow.removeAllListeners('close')
   })
 
-  const status = await stopIpfs()
+  const status = await ctx.stopIpfs()
 
   if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
     autoUpdater.quitAndInstall(true, true)


### PR DESCRIPTION
This fixes #1375 by calling `stopIpfs` on `ctx`. I think that deconstructing `ctx` may be causing that error if and only if `quitAndInstall` was being called before `setupDaemon` [finished executing](https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/src/index.js#L72).

Please validate if this makes sense @lidel.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>