### PR TITLE
feat: support for go-ipfs 0.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - ps: Install-Product node 10 x64
+  - ps: Install-Product node 12 x64
   - npm install
 
 build_script:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "cross-env NODE_ENV=development electron src/index.js",
     "lint": "standard",
     "test": "cross-env NODE_ENV=test mocha test/unit/**/*.spec.js",
-    "test:e2e": "xvfb-maybe cross-env NODE_ENV=test mocha test/e2e/**/*.e2e.js --exit",
+    "test:e2e": "xvfb-maybe cross-env NODE_ENV=test LIBP2P_ALLOW_WEAK_RSA_KEYS=1 mocha test/e2e/**/*.e2e.js --exit",
     "postinstall": "run-s install-app-deps build:webui",
     "install-app-deps": "electron-builder install-app-deps",
     "clean:webui": "shx rm -rf assets/webui/",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "yargs": "^15.3.1"
   },
   "go-ipfs": {
-    "version": "v0.4.23"
+    "version": "v0.5.0-rc1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "yargs": "^15.3.1"
   },
   "go-ipfs": {
-    "version": "v0.5.0-rc1"
+    "version": "v0.5.0-rc2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "yargs": "^15.3.1"
   },
   "go-ipfs": {
-    "version": "v0.5.0-rc2"
+    "version": "v0.5.0-rc3"
   }
 }

--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -109,7 +109,7 @@ const parseCfgMultiaddr = (addr) => (addr.includes('/http')
 
 async function checkIfAddrIsDaemon (addr) {
   const options = {
-    method: 'GET',
+    method: 'POST',
     host: addr.address,
     port: addr.port,
     path: '/api/v0/refs?arg=/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'


### PR DESCRIPTION
This bumps go-ipfs version to 0.5.0-rc1 in preparation for 0.5 release.

Small set of fixes was required:
- Status check
  - switched API calls from `GET` to `POST` (https://github.com/ipfs/go-ipfs/pull/7097)
- Bundled ipfs-webui loaded via Electron's BrowserWindow
  - `Origin` header: a proper value is set instead of removing it
  - sending `ipfs-desktop/${version}` in `User-Agent` header


### TODO before merge

- [ ] ~switch from `"v0.5.0-rc1` to `"v0.5.0` when it ships~ (new PR, see https://github.com/ipfs-shipyard/ipfs-desktop/pull/1392#issuecomment-618093160)

cc @hacdias @Stebalien  https://github.com/ipfs/go-ipfs/issues/7109