### PR TITLE
fix: write path when it does not exist

### DIFF
--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -64,7 +64,7 @@ module.exports = async function (ctx) {
       // Update the path if it was blank previously.
       // This way we use the default path when it is
       // not set.
-      if (config.path === '') {
+      if (!config.path || typeof config.path !== 'string') {
         config.path = ipfsd.repoPath
         store.set('ipfsConfig', config)
         writeIpfsPath(config.path)


### PR DESCRIPTION
This fixes the situation where the user changed the configuration by themselves and removed the path variable or changed its type to something other than string.

The previous check would only update the path is it was an empty string. This way, any invalid path is overwritten.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>