### PR TITLE
feat: run garbage collector

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -43,6 +43,7 @@
   "takeScreenshot": "Take Screenshot",
   "downloadHash": "Download Hash",
   "moveRepositoryLocation": "Move Repository Location",
+  "runGarbageCollector": "Run Garbage Collector",
   "polkitDialog": {
     "title": "Polkit not found",
     "message": "IPFS can't be added to /usr/local/bin/ without polkit agent."
@@ -131,5 +132,14 @@
   "updateDownloadedNotification": {
     "title": "Update downloaded",
     "message": "Update for version { version } of IPFS Desktop downloaded. Click this notification to install."
+  },
+  "runGarbageCollectorWarning": {
+    "title": "Garbage collector",
+    "message": "Running the garbage collector will remove all the objects that are not pinned or on your MFS from your repository. This action might take a while. Do you want to run the Garbage Collector?",
+    "action": "Run GC"
+  },
+  "runGarbageCollectorDone": {
+    "title": "Garbage collector",
+    "message": "Garbage collector run was successful."
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -135,11 +135,11 @@
   },
   "runGarbageCollectorWarning": {
     "title": "Garbage collector",
-    "message": "Running the garbage collector will remove all the objects that are not pinned or on your MFS from your repository. This action might take a while. Do you want to run the Garbage Collector?",
-    "action": "Run GC"
+    "message": "Running the garbage collector will remove from your repository all objects that are not pinned or on your MFS. This may take a while. Do you wish to proceed?",
+    "action": "Run"
   },
   "runGarbageCollectorDone": {
     "title": "Garbage collector",
-    "message": "Garbage collector run was successful."
+    "message": "The garbage collector ran successfully."
   }
 }

--- a/src/run-gc.js
+++ b/src/run-gc.js
@@ -1,0 +1,48 @@
+const i18n = require('i18next')
+const logger = require('./common/logger')
+const { showDialog, recoverableErrorDialog } = require('./dialogs')
+const dock = require('./dock')
+
+module.exports = function runGarbageCollector ({ getIpfsd }) {
+  dock.run(async () => {
+    logger.info('[run gc] alerting user for effects')
+
+    const opt = showDialog({
+      title: i18n.t('runGarbageCollectorWarning.title'),
+      message: i18n.t('runGarbageCollectorWarning.message'),
+      type: 'warning',
+      buttons: [
+        i18n.t('runGarbageCollectorWarning.action'),
+        i18n.t('cancel')
+      ],
+      showDock: false
+    })
+
+    if (opt !== 0) {
+      logger.info('[run gc] user canceled')
+      return
+    }
+
+    const ipfsd = await getIpfsd()
+
+    if (!ipfsd) {
+      return
+    }
+
+    try {
+      ipfsd.api.repo.gc()
+      showDialog({
+        title: i18n.t('runGarbageCollectorDone.title'),
+        message: i18n.t('runGarbageCollectorDone.message'),
+        type: 'info',
+        buttons: [
+          i18n.t('ok')
+        ],
+        showDock: false
+      })
+    } catch (err) {
+      logger.error(`[run gc] ${err.toString()}`)
+      return recoverableErrorDialog(err)
+    }
+  })
+}

--- a/src/tray.js
+++ b/src/tray.js
@@ -9,6 +9,7 @@ const logger = require('./common/logger')
 const store = require('./common/store')
 const { IS_MAC, IS_WIN, VERSION, GO_IPFS_VERSION } = require('./common/consts')
 const moveRepositoryLocation = require('./move-repository-location')
+const runGarbageCollector = require('./run-gc')
 
 // Notes on this: we are only supporting accelerators on macOS for now because
 // they natively work as soon as the menu opens. They don't work like that on Windows
@@ -95,6 +96,12 @@ function buildMenu (ctx) {
         {
           label: i18n.t('moveRepositoryLocation'),
           click: () => { moveRepositoryLocation(ctx) }
+        },
+        {
+          id: 'runGarbageCollector',
+          label: i18n.t('runGarbageCollector'),
+          click: () => { runGarbageCollector(ctx) },
+          enabled: false
         }
       ]
     },
@@ -193,6 +200,7 @@ module.exports = function (ctx) {
 
     menu.getMenuItemById('takeScreenshot').enabled = menu.getMenuItemById('ipfsIsRunning').visible
     menu.getMenuItemById('downloadHash').enabled = menu.getMenuItemById('ipfsIsRunning').visible
+    menu.getMenuItemById('runGarbageCollector').enabled = menu.getMenuItemById('ipfsIsRunning').visible
 
     if (status === STATUS.STARTING_FINISHED) {
       tray.setImage(icon(on))


### PR DESCRIPTION
Supports running the GC from the menubar. This was a feature that was lost during the revamp. Closes #1355.

<img width="586" alt="Screenshot 2020-04-17 at 10 25 17" src="https://user-images.githubusercontent.com/5447088/79554473-037a0700-8096-11ea-8959-a5702a2e4584.png">

<img width="532" alt="Screenshot 2020-04-17 at 10 25 22" src="https://user-images.githubusercontent.com/5447088/79554460-feb55300-8095-11ea-9ee0-dd6a9ab91784.png">

<img width="532" alt="Screenshot 2020-04-17 at 10 25 34" src="https://user-images.githubusercontent.com/5447088/79554447-f9f09f00-8095-11ea-9003-e40bd9692c05.png">

Note: the Electron icon is replaced by IPFS Desktop's icon on the final version.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>