### PR TITLE
fix: circular dependency between dialogs and daemon

### DIFF
--- a/src/daemon/consts.js
+++ b/src/daemon/consts.js
@@ -1,0 +1,10 @@
+module.exports = Object.freeze({
+  STATUS: {
+    STARTING_STARTED: 1,
+    STARTING_FINISHED: 2,
+    STARTING_FAILED: 3,
+    STOPPING_STARTED: 4,
+    STOPPING_FINISHED: 5,
+    STOPPING_FAILED: 6
+  }
+})

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -5,15 +5,7 @@ const createDaemon = require('./daemon')
 const { ipfsNotRunningDialog } = require('../dialogs')
 const store = require('../common/store')
 const logger = require('../common/logger')
-
-const STATUS = {
-  STARTING_STARTED: 1,
-  STARTING_FINISHED: 2,
-  STARTING_FAILED: 3,
-  STOPPING_STARTED: 4,
-  STOPPING_FINISHED: 5,
-  STOPPING_FAILED: 6
-}
+const { STATUS } = require('./consts')
 
 module.exports = async function (ctx) {
   let ipfsd = null

--- a/src/dialogs/ipfs-not-running.js
+++ b/src/dialogs/ipfs-not-running.js
@@ -1,6 +1,6 @@
 const i18n = require('i18next')
 const dialog = require('./dialog')
-const { STATUS } = require('../daemon')
+const { STATUS } = require('../daemon/consts')
 const logger = require('../common/logger')
 
 module.exports = async function ({ startIpfs }) {


### PR DESCRIPTION
Fixes a circular dependency between the dialogs and daemon which was causing `showDialog` not to be available.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>