### PR TITLE
feat(ux):  separate open from other actions

### DIFF
--- a/src/tray.js
+++ b/src/tray.js
@@ -93,6 +93,7 @@ function buildMenu (ctx) {
           label: i18n.t('openConfigFile'),
           click: () => { shell.openItem(store.path) }
         },
+        { type: 'separator' },
         {
           label: i18n.t('moveRepositoryLocation'),
           click: () => { moveRepositoryLocation(ctx) }


### PR DESCRIPTION
This is a small UX nitpick that I thought that makes sense. Please correct me @jessicaschilling @lidel: I added a separator between the 'Open' actions and the other ones. It feels much better now.

Before:

<img width="556" alt="Screenshot 2020-04-18 at 16 55 40" src="https://user-images.githubusercontent.com/5447088/79642457-71592800-8195-11ea-86a3-e2000f5cd5b1.png">

Then:

<img width="483" alt="Screenshot 2020-04-18 at 16 53 18" src="https://user-images.githubusercontent.com/5447088/79642433-54245980-8195-11ea-9c42-4a75a1347c01.png">

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>