### PR TITLE
feat(ux): move preferences to menubar

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -17,7 +17,7 @@
   "readReleaseNotes": "Read Release Notes",
   "status": "Status",
   "files": "Files",
-  "settings": "Settings",
+  "peers": "Peers",
   "quit": "Quit",
   "versions": "Versions",
   "screenshotTaken": "Screenshot taken",
@@ -32,6 +32,7 @@
   "close": "Close",
   "ok": "OK",
   "cancel": "Cancel",
+  "enable": "Enable",
   "reportTheError": "Report the error",
   "restartIpfsDesktop": "Restart IPFS Desktop",
   "openLogs": "Open logs",
@@ -171,5 +172,56 @@
   "couldNotSaveDialog": {
     "title": "Could not write to disk",
     "message": "There was an error writing to the disk. Please try again."
+  },
+  "launchAtLoginNotSupported": {
+    "title": "Error",
+    "message": "Launch at login is not supported on your platform."
+  },
+  "launchAtLoginFailed": {
+    "title": "Error",
+    "message": "Launch at login could not be enabled on your machine."
+  },
+  "enableIpfsOnPath": {
+    "title": "Enable IPFS on PATH",
+    "message": "By enabling this option, IPFS will be available on your command line as \"ipfs\". This action is reversible.",
+    "action": "Enable"
+  },
+  "disableIpfsOnPath": {
+    "title": "Disable IPFS on PATH",
+    "message": "By disabling this option, IPFS will no longer be available on your command line as \"ipfs\".",
+    "action": "Disable"
+  },
+  "enableGlobalTakeScreenshotShortcut": {
+    "title": "Enable screenshot shortcut",
+    "message": "By enabling this, the shortcut \"{ accelerator }\" will be available to take screenshots as long as IPFS Desktop is running."
+  },
+  "enableGlobalDownloadShortcut": {
+    "title": "Enable download shortcut",
+    "message": "By enabling this, the shortcut \"{ accelerator }\" will be available to download files as long as IPFS Desktop is running."
+  },
+  "installNpmOnIpfsWarning": {
+    "title": "Install npm on IPFS",
+    "message": "This experimental feature installs the \"ipfs-npm\" package on your system. It requires Node.js to be installed.",
+    "action": "Install"
+  },
+  "unableToInstallNpmOnIpfs": {
+    "title": "Error",
+    "message": "It was not possible to install \"ipfs-npm\" package on your system. Please check the logs for more information or try installing it manually by running \"npm install -g ipfs-npm\" on your command line."
+  },
+  "unableToUninstallNpmOnIpfs": {
+    "title": "Error",
+    "message": "It was not possible to uninstall \"ipfs-npm\" package on your system. Please check the logs for more information or try uninstalling it manually by running \"npm uninstall -g ipfs-npm\" on your command line."
+  },
+  "settings": {
+    "settings": "Settings",
+    "preferences": "Preferences",
+    "openNodeSettings": "Open Node Settings",
+    "desktopIntegrations": "Desktop Integrations",
+    "launchOnStartup": "Launch at Login",
+    "ipfsCommandLineTools": "Command Line Tools",
+    "takeScreenshotShortcut": "Global Screenshot Shortcut",
+    "downloadHashShortcut": "Global Download Shortcut",
+    "experiments": "Experiments",
+    "npmOnIpfs": "npm on IPFS"
   }
 }

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -216,7 +216,7 @@
     "settings": "Settings",
     "preferences": "Preferences",
     "openNodeSettings": "Open Node Settings",
-    "desktopIntegrations": "Desktop Integrations",
+    "appPreferences": "App Preferences",
     "launchOnStartup": "Launch at Login",
     "ipfsCommandLineTools": "Command Line Tools",
     "takeScreenshotShortcut": "Global Screenshot Shortcut",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s clean:webui build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c bafybeidatpz2hli6fgu3zul5woi27ujesdf5o5a7bu622qj6ugharciwjq -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c bafybeicevz7mmgt45zitnmg73khkmvioz2ozixvd6guujphhtsenu2pt2a -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:binaries": "electron-builder --publish onTag"
   },

--- a/src/dialogs/errors.js
+++ b/src/dialogs/errors.js
@@ -47,7 +47,7 @@ function criticalErrorDialog (e) {
 // Shows a recoverable error dialog with the default title and message.
 // Passing an options object alongside the error can be used to override
 // the title and message.
-function recoverableErrorDialog (e, options = {}) {
+function recoverableErrorDialog (e, options) {
   const cfg = {
     title: i18n.t('recoverableErrorDialog.title'),
     message: i18n.t('recoverableErrorDialog.message'),
@@ -59,12 +59,14 @@ function recoverableErrorDialog (e, options = {}) {
     ]
   }
 
-  if (options.title) {
-    cfg.title = options.title
-  }
+  if (options) {
+    if (options.title) {
+      cfg.title = options.title
+    }
 
-  if (options.message) {
-    cfg.message = options.message
+    if (options.message) {
+      cfg.message = options.message
+    }
   }
 
   const option = dialog(cfg)

--- a/src/download-cid.js
+++ b/src/download-cid.js
@@ -140,7 +140,11 @@ async function downloadCid (ctx) {
 }
 
 module.exports = function (ctx) {
-  setupGlobalShortcut(ctx, {
+  setupGlobalShortcut({
+    confirmationDialog: {
+      title: i18n.t('enableGlobalDownloadShortcut.title'),
+      message: i18n.t('enableGlobalDownloadShortcut.message', { accelerator: SHORTCUT })
+    },
     settingsOption: CONFIG_KEY,
     accelerator: SHORTCUT,
     action: () => {
@@ -151,3 +155,4 @@ module.exports = function (ctx) {
 
 module.exports.downloadCid = downloadCid
 module.exports.SHORTCUT = SHORTCUT
+module.exports.CONFIG_KEY = CONFIG_KEY

--- a/src/npm-on-ipfs/package.js
+++ b/src/npm-on-ipfs/package.js
@@ -1,6 +1,8 @@
 const util = require('util')
+const i18n = require('i18next')
 const logger = require('../common/logger')
 const { IS_WIN } = require('../common/consts')
+const { recoverableErrorDialog } = require('../dialogs')
 const childProcess = require('child_process')
 
 const execFile = util.promisify(childProcess.execFile)
@@ -31,8 +33,12 @@ async function install () {
     await execFile(npmBin, ['install', '-g', 'ipfs-npm'])
     logger.info('[npm on ipfs] ipfs-npm: installed globally')
     return true
-  } catch (e) {
-    logger.error(`[npm on ipfs] ${e.toString()}`)
+  } catch (err) {
+    logger.error(`[npm on ipfs] ${err.toString()}`)
+    recoverableErrorDialog(err, {
+      title: i18n.t('unableToInstallNpmOnIpfs.title'),
+      message: i18n.t('unableToInstallNpmOnIpfs.message')
+    })
     return false
   }
 }
@@ -42,8 +48,12 @@ async function uninstall () {
     await execFile(npmBin, ['uninstall', '-g', 'ipfs-npm'])
     logger.info('[npm on ipfs] ipfs-npm: uninstalled globally')
     return true
-  } catch (e) {
-    logger.error(`[npm on ipfs] ${e.toString()}`)
+  } catch (err) {
+    logger.error(`[npm on ipfs] ${err.toString()}`)
+    recoverableErrorDialog(err, {
+      title: i18n.t('unableToUninstallNpmOnIpfs.title'),
+      message: i18n.t('unableToUninstallNpmOnIpfs.message')
+    })
     return false
   }
 }

--- a/src/take-screenshot.js
+++ b/src/take-screenshot.js
@@ -102,7 +102,11 @@ function takeScreenshot (ctx) {
 }
 
 module.exports = function (ctx) {
-  setupGlobalShortcut(ctx, {
+  setupGlobalShortcut({
+    confirmationDialog: {
+      title: i18n.t('enableGlobalTakeScreenshotShortcut.title'),
+      message: i18n.t('enableGlobalTakeScreenshotShortcut.message', { accelerator: SHORTCUT })
+    },
     settingsOption: CONFIG_KEY,
     accelerator: SHORTCUT,
     action: () => {
@@ -115,3 +119,4 @@ module.exports = function (ctx) {
 
 module.exports.takeScreenshot = takeScreenshot
 module.exports.SHORTCUT = SHORTCUT
+module.exports.CONFIG_KEY = CONFIG_KEY

--- a/src/tray.js
+++ b/src/tray.js
@@ -110,7 +110,7 @@ function buildMenu (ctx) {
         },
         { type: 'separator' },
         {
-          label: i18n.t('settings.desktopIntegrations'),
+          label: i18n.t('settings.appPreferences'),
           enabled: false
         },
         buildCheckbox(AUTO_LAUNCH_KEY, 'settings.launchOnStartup'),

--- a/src/tray.js
+++ b/src/tray.js
@@ -108,6 +108,7 @@ function buildMenu (ctx) {
       label: IS_MAC ? i18n.t('settings.preferences') : i18n.t('settings.settings'),
       submenu: [
         {
+          id: 'webuiNodeSettings',
           label: i18n.t('settings.openNodeSettings'),
           click: () => { ctx.launchWebUI('/settings') }
         },
@@ -259,6 +260,7 @@ module.exports = function (ctx) {
     menu.getMenuItemById('webuiStatus').enabled = status === STATUS.STARTING_FINISHED
     menu.getMenuItemById('webuiFiles').enabled = status === STATUS.STARTING_FINISHED
     menu.getMenuItemById('webuiPeers').enabled = status === STATUS.STARTING_FINISHED
+    menu.getMenuItemById('webuiNodeSettings').enabled = status === STATUS.STARTING_FINISHED
 
     menu.getMenuItemById('startIpfs').enabled = !gcRunning
     menu.getMenuItemById('stopIpfs').enabled = !gcRunning

--- a/src/tray.js
+++ b/src/tray.js
@@ -74,14 +74,17 @@ function buildMenu (ctx) {
     },
     { type: 'separator' },
     {
+      id: 'webuiStatus',
       label: i18n.t('status'),
       click: () => { ctx.launchWebUI('/') }
     },
     {
+      id: 'webuiFiles',
       label: i18n.t('files'),
       click: () => { ctx.launchWebUI('/files') }
     },
     {
+      id: 'webuiPeers',
       label: i18n.t('peers'),
       click: () => { ctx.launchWebUI('/peers') }
     },
@@ -252,6 +255,10 @@ module.exports = function (ctx) {
     menu.getMenuItemById('startIpfs').visible = status === STATUS.STOPPING_FINISHED
     menu.getMenuItemById('stopIpfs').visible = status === STATUS.STARTING_FINISHED
     menu.getMenuItemById('restartIpfs').visible = (status === STATUS.STARTING_FINISHED || errored)
+
+    menu.getMenuItemById('webuiStatus').enabled = status === STATUS.STARTING_FINISHED
+    menu.getMenuItemById('webuiFiles').enabled = status === STATUS.STARTING_FINISHED
+    menu.getMenuItemById('webuiPeers').enabled = status === STATUS.STARTING_FINISHED
 
     menu.getMenuItemById('startIpfs').enabled = !gcRunning
     menu.getMenuItemById('stopIpfs').enabled = !gcRunning

--- a/src/utils/exec-or-sudo.js
+++ b/src/utils/exec-or-sudo.js
@@ -15,7 +15,7 @@ const env = {
   sudo: 'env ELECTRON_RUN_AS_NODE=1'
 }
 
-const getResult = (err, stdout, stderr, scope, failSilently) => {
+const getResult = (err, stdout, stderr, scope, failSilently, errorOptions) => {
   if (stdout) {
     logger.info(`[${scope}] sudo: stdout: ${stdout.toString().trim()}`)
   }
@@ -37,14 +37,14 @@ const getResult = (err, stdout, stderr, scope, failSilently) => {
     } else if (str.includes('User did not grant permission')) {
       dialog.showErrorBox(i18n.t('noPermissionDialog.title'), i18n.t('noPermissionDialog.message'))
     } else {
-      recoverableErrorDialog(err)
+      recoverableErrorDialog(err, errorOptions)
     }
   }
 
   return false
 }
 
-module.exports = async function ({ script, scope, failSilently, trySudo = true }) {
+module.exports = async function ({ script, scope, failSilently, trySudo = true, errorOptions }) {
   const dataArg = `--data="${app.getPath('userData')}"`
   let err = null
 
@@ -61,7 +61,7 @@ module.exports = async function ({ script, scope, failSilently, trySudo = true }
 
   if (!trySudo) {
     if (!failSilently) {
-      recoverableErrorDialog(err)
+      recoverableErrorDialog(err, errorOptions)
     }
 
     return false
@@ -71,7 +71,7 @@ module.exports = async function ({ script, scope, failSilently, trySudo = true }
   const command = `${env.sudo} "${process.execPath}" "${script}" ${dataArg}`
   return new Promise(resolve => {
     sudo.exec(command, { name: 'IPFS Desktop' }, (err, stdout, stderr) => {
-      resolve(getResult(err, stdout, stderr, scope, failSilently))
+      resolve(getResult(err, stdout, stderr, scope, failSilently, errorOptions))
     })
   })
 }

--- a/src/webui/preload.js
+++ b/src/webui/preload.js
@@ -53,22 +53,6 @@ window.ipfsDesktop = {
 
   version: VERSION,
 
-  onConfigChanged: (listener) => {
-    ipcRenderer.on('config.changed', (_, config) => {
-      listener(config)
-    })
-
-    ipcRenderer.send('config.get')
-  },
-
-  toggleSetting: (setting) => {
-    ipcRenderer.send('config.toggle', setting)
-  },
-
-  configHasChanged: () => {
-    ipcRenderer.send('ipfsConfigChanged')
-  },
-
   selectDirectory: () => {
     return new Promise(resolve => {
       remote.dialog.showOpenDialog(remote.getCurrentWindow(), {

--- a/test/unit/create-toggler.spec.js
+++ b/test/unit/create-toggler.spec.js
@@ -3,11 +3,9 @@
 const sinon = require('sinon')
 const chai = require('chai')
 const { expect } = chai
-const os = require('os')
 const dirtyChai = require('dirty-chai')
 const mockElectron = require('./mocks/electron')
 const mockStore = require('./mocks/store')
-const mockWebUI = require('./mocks/webui')
 const mockLogger = require('./mocks/logger')
 
 const proxyquire = require('proxyquire').noCallThru()
@@ -15,12 +13,11 @@ chai.use(dirtyChai)
 
 describe('Create toggler', () => {
   const option = 'OPT'
-  let electron, store, webui, createToggler, logger
+  let electron, store, createToggler, logger
 
   beforeEach(() => {
     electron = mockElectron()
     store = mockStore()
-    webui = mockWebUI()
     logger = mockLogger()
     createToggler = proxyquire('../../src/utils/create-toggler', {
       electron: electron,
@@ -30,107 +27,76 @@ describe('Create toggler', () => {
   })
 
   it('activate option with success', (done) => {
+    const spy = sinon.spy()
     const activate = sinon.stub().returns(true)
-    createToggler({ webui: webui }, option, activate)
-    electron.ipcMain.emit('config.toggle', null, option)
+    createToggler(option, activate)
+
+    electron.ipcMain.on('configUpdated', spy)
+    electron.ipcMain.emit(`toggle_${option}`)
 
     setImmediate(() => {
       expect(store.get.callCount).to.equal(1)
       expect(activate.callCount).to.equal(1)
       expect(store.set.callCount).to.equal(1)
-
-      const args = webui.webContents.send.lastCall.args
-
-      expect(args[0]).to.equal('config.changed')
-      expect(args[1]).to.deep.equal({
-        changed: 'OPT',
-        platform: os.platform(),
-        config: {
-          OPT: true
-        },
-        success: true
-      })
-
+      expect(spy.calledOnce).to.equal(true)
+      expect(store.get(option)).to.equal(true)
       done()
     })
   })
 
   it('activate option with error', (done) => {
+    const spy = sinon.spy()
+    store.set(option, false)
     const activate = sinon.stub().returns(false)
-    createToggler({ webui: webui }, option, activate)
-    electron.ipcMain.emit('config.toggle', null, option)
+    createToggler(option, activate)
 
-    setImmediate(() => {
-      expect(store.get.callCount).to.equal(1)
-      expect(activate.callCount).to.equal(1)
-      expect(store.set.callCount).to.equal(0)
-
-      const args = webui.webContents.send.lastCall.args
-
-      expect(args[0]).to.equal('config.changed')
-      expect(args[1]).to.deep.equal({
-        changed: 'OPT',
-        platform: os.platform(),
-        config: {},
-        success: false
-      })
-
-      done()
-    })
-  })
-
-  it('disable option with success', (done) => {
-    const activate = sinon.stub().returns(true)
-    store.set(option, true)
-
-    createToggler({ webui: webui }, option, activate)
-    electron.ipcMain.emit('config.toggle', null, option)
-
-    setImmediate(() => {
-      expect(store.get.callCount).to.equal(1)
-      expect(activate.callCount).to.equal(1)
-      expect(store.set.callCount).to.equal(2)
-
-      const args = webui.webContents.send.lastCall.args
-
-      expect(args[0]).to.equal('config.changed')
-      expect(args[1]).to.deep.equal({
-        changed: 'OPT',
-        platform: os.platform(),
-        config: {
-          OPT: false
-        },
-        success: true
-      })
-
-      done()
-    })
-  })
-
-  it('disable option with error', (done) => {
-    const activate = sinon.stub().returns(false)
-    store.set(option, true)
-
-    createToggler({ webui: webui }, option, activate)
-    electron.ipcMain.emit('config.toggle', null, option)
+    electron.ipcMain.on('configUpdated', spy)
+    electron.ipcMain.emit(`toggle_${option}`)
 
     setImmediate(() => {
       expect(store.get.callCount).to.equal(1)
       expect(activate.callCount).to.equal(1)
       expect(store.set.callCount).to.equal(1)
+      expect(spy.calledOnce).to.equal(true)
+      expect(store.get(option)).to.equal(false)
+      done()
+    })
+  })
 
-      const args = webui.webContents.send.lastCall.args
+  it('disable option with success', (done) => {
+    store.set(option, true)
+    const spy = sinon.spy()
+    const activate = sinon.stub().returns(true)
+    createToggler(option, activate)
 
-      expect(args[0]).to.equal('config.changed')
-      expect(args[1]).to.deep.equal({
-        changed: 'OPT',
-        platform: os.platform(),
-        config: {
-          OPT: true
-        },
-        success: false
-      })
+    electron.ipcMain.on('configUpdated', spy)
+    electron.ipcMain.emit(`toggle_${option}`)
 
+    setImmediate(() => {
+      expect(store.get.callCount).to.equal(1)
+      expect(activate.callCount).to.equal(1)
+      expect(store.set.callCount).to.equal(2)
+      expect(spy.calledOnce).to.equal(true)
+      expect(store.get(option)).to.equal(false)
+      done()
+    })
+  })
+
+  it('disable option with error', (done) => {
+    store.set(option, true)
+    const spy = sinon.spy()
+    const activate = sinon.stub().returns(false)
+    createToggler(option, activate)
+
+    electron.ipcMain.on('configUpdated', spy)
+    electron.ipcMain.emit(`toggle_${option}`)
+
+    setImmediate(() => {
+      expect(store.get.callCount).to.equal(1)
+      expect(activate.callCount).to.equal(1)
+      expect(store.set.callCount).to.equal(1)
+      expect(spy.calledOnce).to.equal(true)
+      expect(store.get(option)).to.equal(true)
       done()
     })
   })
@@ -138,28 +104,14 @@ describe('Create toggler', () => {
   it('enable and disable option with success', (done) => {
     const activate = sinon.stub().returns(true)
 
-    createToggler({ webui: webui }, option, activate)
-    electron.ipcMain.emit('config.toggle', null, option)
-    electron.ipcMain.emit('config.toggle', null, option)
+    createToggler(option, activate)
+    electron.ipcMain.emit(`toggle_${option}`)
+    electron.ipcMain.emit(`toggle_${option}`)
 
     setImmediate(() => {
       expect(store.get.callCount).to.equal(2)
       expect(activate.callCount).to.equal(2)
       expect(store.set.callCount).to.equal(2)
-      done()
-    })
-  })
-
-  it('do not trigger anything on different option', (done) => {
-    const activate = sinon.spy()
-
-    createToggler({ webui: webui }, option, activate)
-    electron.ipcMain.emit('config.toggle', null, 'ANOTHER_OPTION')
-
-    setImmediate(() => {
-      expect(store.get.callCount).to.equal(0)
-      expect(activate.callCount).to.equal(0)
-      expect(store.set.callCount).to.equal(0)
       done()
     })
   })

--- a/test/unit/mocks/webui.js
+++ b/test/unit/mocks/webui.js
@@ -1,9 +1,0 @@
-const sinon = require('sinon')
-
-module.exports = function mockWebUI () {
-  return {
-    webContents: {
-      send: sinon.spy()
-    }
-  }
-}


### PR DESCRIPTION
This PR removes the Desktop settings from the Web UI panel! Related to #1389.

- See https://github.com/ipfs-shipyard/ipfs-webui/pull/1445 **merged**
- macOS guidelines prefer the term 'Preferences', others OSes users prefer 'Settings'
- Adds the settings under 'Preferences' (macOS) or 'Settings' (others)
- Some that might require more explanation get an information dialog before installing/enabling.
- Errors are now more visible (user gets a dialog). Before, Web UI only said: "error while enabling X".
- Closes #1436 (disables web ui links when node is offline)

<img width="620" alt="Screenshot 2020-04-18 at 18 45 44" src="https://user-images.githubusercontent.com/5447088/79645055-d700e080-81a4-11ea-91ac-d3fb43edb860.png">

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>