### PR TITLE
feat(ux): open Web UI at launch on Linux

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -219,7 +219,7 @@
     "openNodeSettings": "Open Node Settings",
     "appPreferences": "App Preferences",
     "launchOnStartup": "Launch at Login",
-    "launchWebUIOnStartup": "Launch Web UI on Startup",
+    "openWebUIAtLaunch": "Open Web UI at Launch",
     "ipfsCommandLineTools": "Command Line Tools",
     "takeScreenshotShortcut": "Global Screenshot Shortcut",
     "downloadHashShortcut": "Global Download Shortcut",

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -219,6 +219,7 @@
     "openNodeSettings": "Open Node Settings",
     "appPreferences": "App Preferences",
     "launchOnStartup": "Launch at Login",
+    "launchWebUIOnStartup": "Launch Web UI on Startup",
     "ipfsCommandLineTools": "Command Line Tools",
     "takeScreenshotShortcut": "Global Screenshot Shortcut",
     "downloadHashShortcut": "Global Download Shortcut",

--- a/src/tray.js
+++ b/src/tray.js
@@ -14,9 +14,11 @@ const { CONFIG_KEY: DOWNLOAD_KEY, SHORTCUT: DOWNLOAD_SHORTCUT, downloadCid } = r
 const { CONFIG_KEY: AUTO_LAUNCH_KEY, isSupported: supportsLaunchAtLogin } = require('./auto-launch')
 const { CONFIG_KEY: IPFS_PATH_KEY } = require('./ipfs-on-path')
 const { CONFIG_KEY: NPM_IPFS_KEY } = require('./npm-on-ipfs')
+const { CONFIG_KEY: AUTO_LAUNCH_WEBUI_KEY } = require('./webui')
 
 const CONFIG_KEYS = [
   AUTO_LAUNCH_KEY,
+  AUTO_LAUNCH_WEBUI_KEY,
   IPFS_PATH_KEY,
   NPM_IPFS_KEY,
   SCREENSHOT_KEY,
@@ -118,6 +120,7 @@ function buildMenu (ctx) {
           enabled: false
         },
         buildCheckbox(AUTO_LAUNCH_KEY, 'settings.launchOnStartup'),
+        buildCheckbox(AUTO_LAUNCH_WEBUI_KEY, 'settings.launchWebUIOnStartup'),
         buildCheckbox(IPFS_PATH_KEY, 'settings.ipfsCommandLineTools'),
         buildCheckbox(SCREENSHOT_KEY, 'settings.takeScreenshotShortcut'),
         buildCheckbox(DOWNLOAD_KEY, 'settings.downloadHashShortcut'),

--- a/src/tray.js
+++ b/src/tray.js
@@ -120,7 +120,7 @@ function buildMenu (ctx) {
           enabled: false
         },
         buildCheckbox(AUTO_LAUNCH_KEY, 'settings.launchOnStartup'),
-        buildCheckbox(AUTO_LAUNCH_WEBUI_KEY, 'settings.launchWebUIOnStartup'),
+        buildCheckbox(AUTO_LAUNCH_WEBUI_KEY, 'settings.openWebUIAtLaunch'),
         buildCheckbox(IPFS_PATH_KEY, 'settings.ipfsCommandLineTools'),
         buildCheckbox(SCREENSHOT_KEY, 'settings.takeScreenshotShortcut'),
         buildCheckbox(DOWNLOAD_KEY, 'settings.downloadHashShortcut'),

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -76,9 +76,11 @@ const apiOrigin = (apiMultiaddr) => {
 }
 
 module.exports = async function (ctx) {
-  // First time running this. If it's not macOS, nor Windows,
-  // enable launching web ui at login.
   if (store.get(CONFIG_KEY, null) === null) {
+    // First time running this. If it's not macOS, nor Windows,
+    // enable opening ipfs-webui at app launch.
+    // This is the best we can do to mitigate Tray issues on Linux:
+    // https://github.com/ipfs-shipyard/ipfs-desktop/issues/1153
     store.set(CONFIG_KEY, !IS_MAC && !IS_WIN)
   }
 

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -14,7 +14,7 @@ const createToggler = require('../utils/create-toggler')
 
 serve({ scheme: 'webui', directory: join(__dirname, '../../assets/webui') })
 
-const CONFIG_KEY = 'webuiAtLogin'
+const CONFIG_KEY = 'openWebUIAtLaunch'
 
 const createWindow = () => {
   const dimensions = screen.getPrimaryDisplay()


### PR DESCRIPTION
See https://github.com/ipfs-shipyard/ipfs-desktop/issues/1153#issuecomment-616243802.

Adds the option to open Web UI automatically on startup. This is enabled by default when the OS is neither Windows, nor macOS to help users that do not have a tray icon.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>