### PR TITLE
fix(BREAKING): ipfs daemon flags

### DIFF
--- a/src/common/store.js
+++ b/src/common/store.js
@@ -3,18 +3,30 @@ const Store = require('electron-store')
 
 const store = new Store()
 
-if (store.get('version') !== 5) {
+const defaultFlags = [
+  '--migrate',
+  '--enable-gc',
+  '--routing', 'dhtclient'
+]
+
+if (store.get('version', 0) < 5) {
   store.clear()
 
   // default config
   store.set('ipfsConfig', {
     type: 'go',
     path: '',
-    flags: ['--migrate=true', '--routing=dhtclient', '--enable-gc=true'],
+    flags: defaultFlags,
     keysize: 2048
   })
 
   store.set('version', 5)
+}
+
+const flags = store.get('ipfsConfig.flags', [])
+
+if (flags.includes('--migrate=true') || flags.includes('--enable-gc=true')) {
+  store.set('ipfsConfig.flags', defaultFlags)
 }
 
 if (!store.get('language')) {


### PR DESCRIPTION
Fixes the flags we pass to the ipfs daemon. After merging #1392, my daemon wouldn't start because the `--migrate` flag was malformed. We don't need the `=true`. I looked at ipfsd-ctl tests and it seems the flags now should be set like this. Without migrating, the boot would hang.

It may be **breaking** for users that changed the flags by themselves. For simplicty, I just **replaced** the flags in the configuration to:

```javascript
[
  '--migrate',
  '--enable-gc',
  '--routing', 'dhtclient'
]
```

This can be added as a breaking change on the release notes. Probably only some power users know about this and changed it so they'll know what to do once they see this.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>