### PR TITLE
fix: repo fsck is deprecated

### DIFF
--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -17,6 +17,10 @@ function apiFileExists (ipfsd) {
   return fs.pathExistsSync(join(ipfsd.path, 'api'))
 }
 
+function rmApiFile (ipfsd) {
+  return fs.removeSync(join(ipfsd.path, 'api'))
+}
+
 function configPath (ipfsd) {
   return join(ipfsd.path, 'config')
 }
@@ -270,6 +274,7 @@ module.exports = Object.freeze({
   configPath,
   configExists,
   apiFileExists,
+  rmApiFile,
   applyDefaults,
   checkCorsConfig,
   checkPorts


### PR DESCRIPTION
`ipfs repo fsck` seems to have been deprecated (https://github.com/ipfs/go-ipfs/commit/288a83ce7dcbf4a2498e06e4a95245bbb5e30f45) in the meanwhile so our logic wasn't working.

I changed it so now we manually check if it's a connection refused error. If so, check if there's a config file. If so, remove the api file.

If no config file, then it's a remote api connection, show error to the user.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>