### PR TITLE
refactor: use store migrations and defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs-desktop",
   "private": true,
-  "version": "0.10.4",
+  "version": "0.11.0",
   "productName": "IPFS Desktop",
   "description": "IPFS Native Application",
   "main": "src/index.js",


### PR DESCRIPTION
Refactors store to use the package defaults and migrations to allow for
easy configuration migrations and defaults. The migrations use the package
version, hence the bump.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>