### PR TITLE
fix: keep track of last opened page

### DIFF
--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -96,12 +96,17 @@ module.exports = async function (ctx) {
 
   ctx.webui = window
 
-  ctx.launchWebUI = (url, { focus = true } = {}) => {
-    if (!url) {
+  const url = new URL('/', 'webui://-')
+  url.hash = '/blank'
+  url.searchParams.set('deviceId', ctx.countlyDeviceId)
+
+  ctx.launchWebUI = (path, { focus = true } = {}) => {
+    if (!path) {
       logger.info('[web ui] launching web ui')
     } else {
-      logger.info(`[web ui] navigate to ${url}`)
-      window.webContents.send('updatedPage', url)
+      logger.info(`[web ui] navigate to ${path}`)
+      window.webContents.send('updatedPage', path)
+      url.hash = path
     }
 
     if (focus) {
@@ -110,10 +115,6 @@ module.exports = async function (ctx) {
       dock.show()
     }
   }
-
-  const url = new URL('/', 'webui://-')
-  url.hash = '/blank'
-  url.searchParams.set('deviceId', ctx.countlyDeviceId)
 
   function updateLanguage () {
     url.searchParams.set('lng', store.get('language'))
@@ -126,6 +127,7 @@ module.exports = async function (ctx) {
       apiAddress = ipfsd.apiAddr
       url.searchParams.set('api', apiAddress)
       updateLanguage()
+      console.log(url.toString())
       window.loadURL(url.toString())
     }
   })

--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -127,7 +127,6 @@ module.exports = async function (ctx) {
       apiAddress = ipfsd.apiAddr
       url.searchParams.set('api', apiAddress)
       updateLanguage()
-      console.log(url.toString())
       window.loadURL(url.toString())
     }
   })

--- a/src/webui/preload.js
+++ b/src/webui/preload.js
@@ -12,6 +12,15 @@ connectionHook()
 
 const urlParams = new URLSearchParams(window.location.search)
 
+function checkIfVisible () {
+  if (document.hidden) {
+    previousHash = window.location.hash
+    window.location.hash = '/blank'
+  } else {
+    window.location.hash = previousHash
+  }
+}
+
 var originalSetItem = window.localStorage.setItem
 window.localStorage.setItem = function () {
   if (arguments[0] === 'i18nextLng') {
@@ -29,12 +38,11 @@ ipcRenderer.on('updatedPage', (_, url) => {
 })
 
 document.addEventListener('visibilitychange', () => {
-  if (document.hidden) {
-    previousHash = window.location.hash
-    window.location.hash = '/blank'
-  } else {
-    window.location.hash = previousHash
-  }
+  checkIfVisible()
+})
+
+document.addEventListener('DOMContentReady', () => {
+  checkIfVisible()
 })
 
 window.ipfsDesktop = {


### PR DESCRIPTION
Fixes #1451. Keeps track of the last opened page so every time we need to refresh because a change on the IPFS status, we can keep the user on the same page. The visibility (`/blank` handling) is taken care on the `preload.js`.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>