### PR TITLE
fix: go-ipfs 0.5.0 with go-ipfs-dep 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,13 +1968,6 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "requires": {
         "pako": "~0.2.0"
-      },
-      "dependencies": {
-        "pako": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-        }
       }
     },
     "bs58": {
@@ -4974,9 +4967,9 @@
       }
     },
     "go-ipfs-dep": {
-      "version": "0.4.23-3",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.23-3.tgz",
-      "integrity": "sha512-jdLKEax5pGVoPJn2ZayYSGt0SXPI9osr6cj87cWB9PGJ7p/tkPSzMHNpVHwYU1aY9SjUcuU8KzqMUn1KOCK5FA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.5.0.tgz",
+      "integrity": "sha512-Ycv47Nydg7C9ochR40LIlpRGnJAq7lh9S9o3NW3hXX03TZu7m9mx3LIzJia2zFJUdH7RhZ4103QCHmaQlFXCgQ==",
       "requires": {
         "go-platform": "^1.0.0",
         "gunzip-maybe": "^1.4.1",
@@ -5137,9 +5130,9 @@
       "dev": true
     },
     "gunzip-maybe": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
-      "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
+      "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
       "requires": {
         "browserify-zlib": "^0.1.4",
         "is-deflate": "^1.0.0",
@@ -7823,6 +7816,11 @@
           }
         }
       }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs-desktop",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.0",
   "productName": "IPFS Desktop",
   "description": "IPFS Native Application",
   "main": "src/index.js",
@@ -81,7 +81,7 @@
     "fix-path": "^3.0.0",
     "fs-extra": "^9.0.0",
     "i18next": "^19.4.4",
-    "go-ipfs-dep": "^0.4.23-3",
+    "go-ipfs-dep": "0.5.0",
     "i18next-electron-language-detector": "0.0.10",
     "i18next-icu": "^1.3.1",
     "i18next-node-fs-backend": "^2.1.3",
@@ -101,8 +101,5 @@
     "which": "^2.0.2",
     "winston": "^3.2.1",
     "yargs": "^15.3.1"
-  },
-  "go-ipfs": {
-    "version": "v0.5.0"
   }
 }


### PR DESCRIPTION
For some reason CI included 0.4.23, ignoring the go-ipfs key in
package.json. Hopefully this will fix it.
