### PR TITLE
fix: ipfs on PATH on windows with spaces in binary path

### DIFF
--- a/src/ipfs-on-path/scripts/bin-win/ipfs.cmd
+++ b/src/ipfs-on-path/scripts/bin-win/ipfs.cmd
@@ -5,4 +5,4 @@ if exist "%USERPROFILE%\.ipfs-desktop\IPFS_PATH" (
 )
 
 SET /P IPFS_EXEC=<"%USERPROFILE%\.ipfs-desktop\IPFS_EXEC"
-%IPFS_EXEC% %*
+"%IPFS_EXEC%" %*


### PR DESCRIPTION
License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>