### PR TITLE
docs: improve error reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: need/triage
 assignees: ''
 
 ---
+ - OS: [e.g. macOS, Windows, Linux]
+ - Version of IPFS Desktop [e.g. 0.11.1]
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -23,16 +25,14 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
 **Additional context**
 Add any other context about the problem here.
+
+<!-- 
+ATTACH LOGS
+
+If possible:
+1. Go to `Advanced` → `Open Logs Directory`
+2. Find `*.log` files
+3. Attach `error.log` and `combined.log` to this issue.
+-->


### PR DESCRIPTION
This PR improves Bug reporting template by adding instruction on where to find error logs and asking reporter to attach them to the bug report.

This should save us the usual 1-2 roundtrips in most of  cases.


Thank you to @achingbrain for inspiration :-)
