### PR TITLE
fix(ci): skip notarization if signing was skipped

### DIFF
--- a/pkgs/macos/notarize-build.js
+++ b/pkgs/macos/notarize-build.js
@@ -1,6 +1,8 @@
 require('dotenv').config()
 const { notarize } = require('electron-notarize')
 
+const isSet = (value) => value && value !== 'false'
+
 // electron-build hook to be used in electron-build pipeline in the future
 // ===========================================================================
 // Note: for now we don't use this at the moment.
@@ -10,6 +12,11 @@ exports.default = async function notarizing (context) {
   if (electronPlatformName !== 'darwin') return
   // skip notarization if secrets are not present in env
   if (!process.env.APPLEID || !process.env.APPLEIDPASS) return
+  // skip notarization when signing is disabled in PRs
+  // https://github.com/electron-userland/electron-builder/commit/e1dda14
+  if (isSet(process.env.TRAVIS_PULL_REQUEST) ||
+    isSet(process.env.CI_PULL_REQUEST) ||
+    isSet(process.env.CI_PULL_REQUESTS)) return
 
   const appName = context.packager.appInfo.productFilename
 


### PR DESCRIPTION
electron-builder skips signing in PRs (https://github.com/electron-userland/electron-builder/commit/e1dda14) so we should skip notarization as well to speed up the CI and avoid unnecessary errors ([example](https://travis-ci.com/github/ipfs-shipyard/ipfs-desktop/jobs/333268431#L323-L327)).