### PR TITLE
fix: added daemon functions to the auto-updater

### DIFF
--- a/src/auto-updater/quit-and-install.js
+++ b/src/auto-updater/quit-and-install.js
@@ -1,6 +1,5 @@
 const { app, BrowserWindow } = require('electron')
 const { autoUpdater } = require('electron-updater')
-const { STATUS } = require('../daemon')
 const logger = require('../common/logger')
 
 // adapted from https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
@@ -13,12 +12,10 @@ module.exports = async function quitAndInstall ({ stopIpfs }) {
 
   try {
     const status = await stopIpfs()
-
-    if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
-      autoUpdater.quitAndInstall(true, true)
-    }
+    logger.info(`[quit-and-install] stopIpfs had finished with status: ${status}`)
   } catch (err) {
-    logger.error(err)
-    autoUpdater.quitAndInstall(true, true)
+    logger.error('[quit-and-install] stopIpfs had an error', err)
   }
+
+  autoUpdater.quitAndInstall(true, true)
 }

--- a/src/auto-updater/quit-and-install.js
+++ b/src/auto-updater/quit-and-install.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow } = require('electron')
 const { autoUpdater } = require('electron-updater')
 const { STATUS } = require('../daemon')
+const logger = require('../common/logger')
 
 // adapted from https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
 module.exports = async function quitAndInstall ({ stopIpfs }) {
@@ -10,9 +11,14 @@ module.exports = async function quitAndInstall ({ stopIpfs }) {
     browserWindow.removeAllListeners('close')
   })
 
-  const status = await stopIpfs()
+  try {
+    const status = await stopIpfs()
 
-  if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
+    if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
+      autoUpdater.quitAndInstall(true, true)
+    }
+  } catch(err) {
+    logger.error(err)
     autoUpdater.quitAndInstall(true, true)
   }
 }

--- a/src/auto-updater/quit-and-install.js
+++ b/src/auto-updater/quit-and-install.js
@@ -17,7 +17,7 @@ module.exports = async function quitAndInstall ({ stopIpfs }) {
     if (status === STATUS.STOPPING_FAILED || status === STATUS.STOPPING_FINISHED) {
       autoUpdater.quitAndInstall(true, true)
     }
-  } catch(err) {
+  } catch (err) {
     logger.error(err)
     autoUpdater.quitAndInstall(true, true)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -66,10 +66,10 @@ async function run () {
     await setupI18n(ctx)
     await setupAppMenu(ctx)
 
-    await setupAutoUpdater(ctx) // ctx.checkForUpdates
     await setupWebUI(ctx) // ctx.webui, launchWebUI
     await setupTray(ctx) // ctx.tray
     await setupDaemon(ctx) // ctx.getIpfsd, startIpfs, stopIpfs, restartIpfs
+    await setupAutoUpdater(ctx) // ctx.checkForUpdates
 
     await Promise.all([
       setupArgvFilesHandler(ctx),


### PR DESCRIPTION
Fixes #1508, fixes #1496, fixes #1375

- I'm not able to test this for sure because autoUpdater doesn't work on dev mode.

The problem was that the autoUpdater was trying to access the `stopIpfs` from the context (`ctx` variable), but that would only be initialized with the functions after `setupDaemon` has been executed.
