### PR TITLE
feat: go-ipfs 0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4855,9 +4855,9 @@
       }
     },
     "go-ipfs-dep": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.5.1.tgz",
-      "integrity": "sha512-N8SB3VJLIIGwWATAJkAbvnwv8e4ddb0krrG4FhMq71uP0gu90itAG3ZujYZV0gkJH1rWK+U7huaPpFk6QU4rbQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.6.0.tgz",
+      "integrity": "sha512-pehz8LM8RBRW0+u6L6J4XPb1Fs5mj9wJ89F4B3gyBG/z1zMeTYO6wqcgphfHBtK/uHAu4Ce0nCFR8TGClP8bBg==",
       "requires": {
         "go-platform": "^1.0.0",
         "gunzip-maybe": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "url": "https://github.com/ipfs-shipyard/ipfs-desktop/issues"
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-desktop",
-  "go-ipfs": {
-    "version": "v0.6.0-rc7"
-  },
   "devDependencies": {
     "@svgr/cli": "^5.4.0",
     "chai": "^4.2.0",
@@ -83,7 +80,7 @@
     "electron-updater": "^4.3.1",
     "fix-path": "^3.0.0",
     "fs-extra": "^9.0.0",
-    "go-ipfs-dep": "0.5.1",
+    "go-ipfs-dep": "0.6.0",
     "i18next": "^19.4.4",
     "i18next-electron-language-detector": "0.0.10",
     "i18next-icu": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "url": "https://github.com/ipfs-shipyard/ipfs-desktop/issues"
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-desktop",
+  "go-ipfs": {
+    "version": "v0.6.0-rc1"
+  },
   "devDependencies": {
     "@svgr/cli": "^5.4.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-desktop",
   "go-ipfs": {
-    "version": "v0.6.0-rc6"
+    "version": "v0.6.0-rc7"
   },
   "devDependencies": {
     "@svgr/cli": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/ipfs-shipyard/ipfs-desktop",
   "go-ipfs": {
-    "version": "v0.6.0-rc1"
+    "version": "v0.6.0-rc6"
   },
   "devDependencies": {
     "@svgr/cli": "^5.4.0",


### PR DESCRIPTION
This PR bumps go-ipfs to 0.6

Before merging:

- [x] test locally with RC1
- [x] wait for final release
- [x] remove `go-ipfs` block from `package.json` and update `go-ipfs-dep` to `0.6.0`