### PR TITLE
feat: ipfs-webui v2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:webui": "shx rm -rf assets/webui/",
     "build": "run-s clean:webui build:*",
     "build:webui": "run-s build:webui:*",
-    "build:webui:download": "npx ipfs-or-gateway -c bafybeicp23nbcxtt2k2twyfivcbrc6kr3l5lnaiv3ozvwbemtrb7v52r6i -p assets/webui/ -t 360000 --verbose",
+    "build:webui:download": "npx ipfs-or-gateway -c bafybeigkbbjnltbd4ewfj7elajsbnjwinyk6tiilczkqsibf3o7dcr6nn4 -p assets/webui/ -t 360000 --verbose",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
     "build:binaries": "electron-builder --publish onTag"
   },


### PR DESCRIPTION
https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.9.0

@rafaelramalho19 FYSA this is release I created in hope to ship in go-ipfs 0.6. 

(I am creating PRs for all repos listed in https://github.com/ipfs-shipyard/ipfs-webui#releasing because I forgot the last time and v2.8.0 did not propagate everywhere)