### PR TITLE
fix(ci): disable snap login and publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_script:
       sudo apt update
       sudo apt install -y rpm snapd
       sudo snap install snapcraft --classic
-      echo $SNAP_TOKEN | snapcraft login --with -
     fi
 
 script:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -63,9 +63,7 @@ snap:
     - network-bind
     - removable-media
   publish:
-    - provider: snapStore
-      channels:
-        - stable
+    - github
 
 publish:
   - github


### PR DESCRIPTION
This PR fixes recent CI failures by reverting #1156 

### Details

This removes login to the third party service during our CI build and publishes `.snap` package to github release, instead of snapcraft.io, which breaks CI when tokens expire ([example](https://travis-ci.com/github/ipfs-shipyard/ipfs-desktop/jobs/346643502#L497)).
    
### Rationale

- our CI should not log into a third party service on every build
- publishing to third party package stores should not determine if release build is successful or not 
  - it should be a separate step, after successful release build
