### PR TITLE
fix: ensure small asar archive

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,13 @@
 appId: io.ipfs.desktop
 generateUpdatesFilesForAllChannels: true
 
+files:
+  - filter:
+    - src/**/*
+    - assets/**/*
+    - node_modules/**/*
+    - package.json
+
 directories:
   buildResources: assets/build
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:webui": "run-s build:webui:*",
     "build:webui:download": "npx ipfs-or-gateway -c bafybeifekmcbbi4nwyj4aasti6x3nuhyli464wfjjfdjg4xnz53lhyiedq -p assets/webui/ -t 360000 --verbose --clean",
     "build:webui:minimize": "shx rm -rf assets/webui/static/js/*.map && shx rm -rf assets/webui/static/css/*.map",
-    "build:packages": "shx rm -rf dist/ && electron-builder --publish onTag"
+    "package": "shx rm -rf dist/ && run-s build && electron-builder --publish onTag"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Closes #1659 and unblocks v0.13

- [x] stop including `.cache` and other unwanted paths
- [x] <del>include go-ipfs binary only once, in unpacked form</del> 
  - turns out removing duplicate go-ipfs from `asar` archive saves us "only" ~1MB, so not worth it
  - we could remove it, but it would break [path detection](https://github.com/ipfs/npm-go-ipfs/blob/v0.7.0/src/index.js) which expect binary to be present (and if we remove it from `asar` no binary will be found). for sake of keeping codebase simple, lets leave it as-is.


I am going to merge this and re-create release draft for v0.13 with smaller binaries.
Then, we will smoke-test them to see if linux/macOS/Windows work as expected.