### PR TITLE
feat(ci): automated Snapcraft publishing

### DIFF
--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -1,0 +1,24 @@
+name: snapcraft
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download .snap artifact
+        uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c # 0.0.5
+        with:
+          repo: ipfs-shipyard/ipfs-desktop
+          version: tags/${{ github.event.release.tag_name }}
+          file: ipfs-desktop-${{ github.event.release.name }}-linux-amd64.snap
+
+      - name: Publish to Snapcraft
+        uses: snapcore/action-publish@f1879414dc5500e02a36f3d715bca6ddd438c913 # 1.0.2
+        with:
+          store_login: ${{ secrets.SNAP_STORE_LOGIN }}
+          snap: ipfs-desktop-${{ github.event.release.name }}-linux-amd64.snap
+          release: stable

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Other languages are periodically pulled from [Transifex](https://www.transifex.c
   - The `latest.yml, latest-mac.yml, latest-linux.yml` files on the release are used by the app to determine when an app update is available.
 - Update links and badges in `README` to point to the new version (`A.B.C`)
 - Update selected package managers
-  - Update [Snap](https://snapcraft.io/ipfs-desktop).
+  - Wait for Github Action to finish and confirm it updated [Snap](https://snapcraft.io/ipfs-desktop).
   - Update [Homebrew Cask](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).
   - Update Chocolatey package:
       1. Wait for the artefact on the [releases page](https://github.com/ipfs-shipyard/ipfs-desktop/releases)


### PR DESCRIPTION
This PR aims to remove the need for manually publishing snap to Snapcraft.
Closes https://github.com/ipfs-shipyard/ipfs-desktop/issues/1551

- The workflow is triggered when a new release is published.
- It assumes `.snap` is attached to the release, 
  - downloads it 
    - and then publishes it to Snapcraft at snapcraft.io/ipfs-desktop
