### PR TITLE
fix: openItem errors

### DIFF
--- a/src/common/notify.js
+++ b/src/common/notify.js
@@ -16,7 +16,7 @@ function notifyError ({ title, body = '' }) {
     title,
     body: `${body} ${i18n.t('clickToOpenLogs')}`.trim()
   }, () => {
-    shell.openItem(app.getPath('userData'))
+    shell.openPath(app.getPath('userData'))
   })
 }
 

--- a/src/daemon/config.js
+++ b/src/daemon/config.js
@@ -205,7 +205,7 @@ async function checkPortsArray (ipfsd, addrs) {
       })
 
       if (opt === 0) {
-        shell.openItem(join(ipfsd.path, 'config'))
+        shell.openPath(join(ipfsd.path, 'config'))
       }
 
       throw new Error('ports already being used')

--- a/src/dialogs/errors.js
+++ b/src/dialogs/errors.js
@@ -1,4 +1,5 @@
 const { app, shell } = require('electron')
+const path = require('path')
 const i18n = require('i18next')
 const dialog = require('./dialog')
 
@@ -20,6 +21,8 @@ ${e.stack}
 
 let hasErrored = false
 
+const newIssueUrl = (e) => `https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=${encodeURI(issueTemplate(e))}`.substring(0, 1999)
+
 function criticalErrorDialog (e) {
   if (hasErrored) return
   hasErrored = true
@@ -38,7 +41,7 @@ function criticalErrorDialog (e) {
   if (option === 0) {
     app.relaunch()
   } else if (option === 2) {
-    shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=${encodeURI(issueTemplate(e))}`)
+    shell.openExternal(newIssueUrl(e))
   }
 
   app.exit(1)
@@ -72,9 +75,9 @@ function recoverableErrorDialog (e, options) {
   const option = dialog(cfg)
 
   if (option === 1) {
-    shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/issues/new?body=${encodeURI(issueTemplate(e))}`)
+    shell.openExternal(newIssueUrl(e))
   } else if (option === 2) {
-    shell.openItem(app.getPath('userData'))
+    shell.openPath(path.join(app.getPath('userData'), 'combined.log'))
   }
 }
 

--- a/src/tray.js
+++ b/src/tray.js
@@ -200,7 +200,7 @@ function buildMenu (ctx) {
         { type: 'separator' },
         {
           label: i18n.t('viewOnGitHub'),
-          click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/') }
+          click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/README.md') }
         },
         {
           label: i18n.t('helpUsTranslate'),

--- a/src/tray.js
+++ b/src/tray.js
@@ -138,15 +138,15 @@ function buildMenu (ctx) {
       submenu: [
         {
           label: i18n.t('openLogsDir'),
-          click: () => { shell.openItem(app.getPath('userData')) }
+          click: () => { shell.openPath(app.getPath('userData')) }
         },
         {
           label: i18n.t('openRepoDir'),
-          click: () => { shell.openItem(store.get('ipfsConfig.path')) }
+          click: () => { shell.openPath(store.get('ipfsConfig.path')) }
         },
         {
           label: i18n.t('openConfigFile'),
-          click: () => { shell.openItem(store.path) }
+          click: () => { shell.openPath(store.path) }
         },
         { type: 'separator' },
         {
@@ -184,13 +184,13 @@ function buildMenu (ctx) {
         },
         {
           label: `ipfs-desktop ${VERSION}`,
-          click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/releases') }
+          click: () => { shell.openExternal(`https://github.com/ipfs-shipyard/ipfs-desktop/releases/v${VERSION}`) }
         },
         {
           label: hasCustomBinary()
             ? i18n.t('customIpfsBinary')
             : `go-ipfs ${GO_IPFS_VERSION}`,
-          click: () => { shell.openExternal('https://github.com/ipfs/go-ipfs/releases') }
+          click: () => { shell.openExternal(`https://github.com/ipfs/go-ipfs/releases/v${GO_IPFS_VERSION}`) }
         },
         { type: 'separator' },
         {
@@ -200,11 +200,11 @@ function buildMenu (ctx) {
         { type: 'separator' },
         {
           label: i18n.t('viewOnGitHub'),
-          click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/blob/master/README.md') }
+          click: () => { shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/') }
         },
         {
           label: i18n.t('helpUsTranslate'),
-          click: () => { shell.openExternal('https://www.transifex.com/ipfs/ipfs-desktop/') }
+          click: () => { shell.openExternal('https://www.transifex.com/ipfs/public/') }
         }
       ]
     },


### PR DESCRIPTION
This PR


-  replaces deprecated `openItem` with `openPath` (closes #1676 & closes  #1677)
   necessary due to https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md
- makes some links more useful by linking to specific version
- limits the length of URL for bug reporting to ~2k characters (closes #1530)

Edit: also closes #1685, closes #1686, closes https://github.com/ipfs-shipyard/ipfs-desktop/issues/1688.