### PR TITLE
feat: screenshot improvements

### DIFF
--- a/src/take-screenshot.js
+++ b/src/take-screenshot.js
@@ -67,10 +67,11 @@ function handleScreenshot (ctx) {
     try {
       await makeScreenshotDir(ipfs)
       const isDir = output.length > 1
-      const rawDate = new Date()
-      const date = `${rawDate.getFullYear()}-${rawDate.getMonth()}-${rawDate.getDate()}`
-      const time = `${rawDate.getHours()}.${rawDate.getMinutes()}.${rawDate.getMilliseconds()}`
-      let baseName = `/screenshots/${date} ${time}`
+      const d = new Date()
+      const pad = n => String(n).padStart(2, '0')
+      const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+      const time = `${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getMilliseconds())}`
+      let baseName = `/screenshots/${date}_${time}`
 
       if (isDir) {
         baseName += '/'


### PR DESCRIPTION
This ensures the CID is properly passed to copied link, and that filename is preserved when a single screen setup is used (produces single screenshot). Switched to reliable gateway, as share.ipfs.io is not maintained.

We also avoid low level pinning  (MFS is enough) and ensure the produced CID is the same as on CLI (avoiding problems described in https://github.com/ipfs-shipyard/ipfs-webui/issues/676).