### PR TITLE
fix: use correct config path during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ The configuration file and logs are located on:
 
 For quick access to this folders, just right-click on your tray icon and then 'Logs Directory' or 'Configuration File', depending on what you want.
 
-**Note for developers:** When running dev version via `npm start` configuration will be placed in `/Electron/` instead of `/IPFS Desktop/` (`~/.config/Electron/config.json` on Linux). This is a known limitation of dev mode, does not impact packaged versions.
-
 ### How do we select the IPFS repo location?
 
 We use [ipfsd-ctl](https://github.com/ipfs/js-ipfsd-ctl), which, in default conditions, will check `IPFS_PATH` environment variable. If not set, we fallback to `$HOME/.ipfs`. As soon as the first run has succeded, we save the information about the repository location in the configuration file, which becomes the source of truth.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "IPFS Native Application",
   "main": "src/index.js",
   "scripts": {
-    "start": "cross-env NODE_ENV=development electron src/index.js",
+    "start": "cross-env NODE_ENV=development electron .",
     "lint": "standard",
     "test": "cross-env NODE_ENV=test mocha test/unit/**/*.spec.js",
     "test:e2e": "xvfb-maybe cross-env NODE_ENV=test LIBP2P_ALLOW_WEAK_RSA_KEYS=1 mocha test/e2e/**/*.e2e.js --exit",


### PR DESCRIPTION
This PR makes instance started via `npm start` read `package.json` and that makes Electron to use config from `~/.config/IPFS Desktop` instead of `~/.config/Electron`.

Goal here is to have the same behavior in dev as  in packaged production version, reducing the surface for human error (eg. I was removing `~/.config/IPFS Desktop` between tests while `~/.config/Electron` remained with broken config)

@hacdias @olizilla cc fyi (I remember this  being an issue in past, this seems to be the fix)