### PR TITLE
fix: OS integrations for quick file import

### DIFF
--- a/src/add-to-ipfs.js
+++ b/src/add-to-ipfs.js
@@ -32,7 +32,7 @@ async function makeShareableObject (ipfs, results) {
     return results[0]
   }
 
-  let baseCID = await ipfs.object.new('unixfs-dir')
+  let baseCID = await ipfs.object.new({ template: 'unixfs-dir' })
 
   for (const { cid, path, size } of results) {
     baseCID = (await ipfs.object.patch.addLink(baseCID, {

--- a/src/add-to-ipfs.js
+++ b/src/add-to-ipfs.js
@@ -87,11 +87,7 @@ module.exports = async function ({ getIpfsd, launchWebUI }, files) {
 
   await Promise.all(files.map(async file => {
     try {
-      let result = null
-      for await (const res of ipfsd.api.add(globSource(file, { recursive: true }))) {
-        result = res
-      }
-
+      const result = await ipfsd.api.add(globSource(file, { recursive: true }))
       await copyFile(ipfsd.api, result.cid, result.path)
       successes.push(result)
     } catch (e) {


### PR DESCRIPTION
This PR refactors code to fix bugs caused by [js api changes](https://blog.ipfs.io/2020-02-01-async-await-refactor/).

The sneaky one: the way we pass template changed in a way that failed silently:
https://github.com/ipfs/js-ipfs/blob/8cb8c73037e44894d756b70f344b3282463206f9/packages/interface-ipfs-core/src/object/new.js#L33-L40
so instead of unixfs, we were patching untyped object, which gateway was unable to render.

@rafaelramalho19 
I've pushed 1 line fix to your branch and created this PR to include our fixes.


### How to test

Same code is used for different variant on each OS, so we need to test both.

#### macOS

- [x] drag&drop multiple files or a file and a directory to desktop's icon

#### Windows

- [x] right click on a file and select "Add to IPFS" from context menu

Closes #1684