### PR TITLE
fix: autoupdate only on supported platforms

### DIFF
--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -5,7 +5,13 @@ const logger = require('../common/logger')
 const { notify } = require('../common/notify')
 const { showDialog } = require('../dialogs')
 const macQuitAndInstall = require('./macos-quit-and-install')
-const { IS_MAC } = require('../common/consts')
+const { IS_MAC, IS_WIN, IS_APPIMAGE } = require('../common/consts')
+
+function isAutoUpdateSupported () {
+  // atm only macOS, windows and AppImage builds support autoupdate mechanism,
+  // everything else needs to be updated manually or via a third-party package manager
+  return IS_MAC || IS_WIN || IS_APPIMAGE
+}
 
 let feedback = false
 
@@ -137,6 +143,12 @@ module.exports = async function (ctx) {
     }
     return
   }
+  if (!isAutoUpdateSupported()) {
+    ctx.manualCheckForUpdates = () => {
+      shell.openExternal('https://github.com/ipfs-shipyard/ipfs-desktop/releases/latest')
+    }
+    return
+  }
 
   setup(ctx)
 
@@ -144,6 +156,7 @@ module.exports = async function (ctx) {
 
   setInterval(checkForUpdates, 43200000) // every 12 hours
 
+  // enable on-demand check via About submenu
   ctx.manualCheckForUpdates = () => {
     feedback = true
     checkForUpdates()

--- a/src/common/consts.js
+++ b/src/common/consts.js
@@ -4,6 +4,7 @@ const packageJson = require('../../package.json')
 module.exports = Object.freeze({
   IS_MAC: os.platform() === 'darwin',
   IS_WIN: os.platform() === 'win32',
+  IS_APPIMAGE: typeof process.env.APPIMAGE !== 'undefined',
   VERSION: packageJson.version,
   ELECTRON_VERSION: packageJson.dependencies.electron,
   GO_IPFS_VERSION: packageJson.dependencies['go-ipfs'],


### PR DESCRIPTION
This PR:

- disables autoupdate on platforms other than macOS, Windows and AppImage, solving problem described in #1671
- on platforms that do not have built-in autoupdate we assume a third-party package manager is used
  - The `About → Check for Update..` menu item is still present, but instead of built-in check it opens https://github.com/ipfs-shipyard/ipfs-desktop/releases/latest

Closes #1671 and also historical  #1683 / #1274 / #928
