### PR TITLE
Explicitly specify content-type in prompt template

### DIFF
--- a/src/dialogs/prompt/template.js
+++ b/src/dialogs/prompt/template.js
@@ -1,7 +1,7 @@
 module.exports = ({ pallette, message, defaultValue, buttons, id }) => (`<!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta charset="utf-8" /> 
   </head>
   <body>
     <p>${message}</p>

--- a/src/dialogs/prompt/template.js
+++ b/src/dialogs/prompt/template.js
@@ -1,5 +1,8 @@
 module.exports = ({ pallette, message, defaultValue, buttons, id }) => (`<!DOCTYPE html>
 <html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  </head>
   <body>
     <p>${message}</p>
     <input type="text" value="${defaultValue}" />


### PR DESCRIPTION
Closes https://github.com/ipfs-shipyard/ipfs-desktop/issues/1728.

This PR explicitly specifies `utf-8` content-type in the template for the "Download..." dialog so non-roman languages don't blow out.

Tested in Mac Big Sur **only**; would appreciate a look in Linux/Windows.

### Before
![image](https://user-images.githubusercontent.com/16832365/103969287-8d2bb080-51a0-11eb-93c7-d55382b5bbd8.png)

### After
![image](https://user-images.githubusercontent.com/1507828/104048602-bba98b80-51a0-11eb-81c4-d0f9e1a51a1c.png)
