### PR TITLE
feat: enable pubsub via settings menu

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -223,6 +223,7 @@
     "appPreferences": "App Preferences",
     "launchOnStartup": "Launch at Login",
     "openWebUIAtLaunch": "Open Web UI at Launch",
+    "pubsub": "Enable PubSub",
     "ipfsCommandLineTools": "Command Line Tools",
     "takeScreenshotShortcut": "Global Screenshot Shortcut",
     "downloadHashShortcut": "Global Download Shortcut",

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,14 +350,6 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "@hapi/ammo": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
@@ -375,9 +367,9 @@
       }
     },
     "@hapi/boom": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
+      "integrity": "sha512-VNR8eDbBrOxBgbkddRYIe7+8DZ+vSbV6qlmaN2x7eWjsUjy2VmQgChkOKcVZIeupEZYj+I0dqNg430OhwzagjA==",
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -446,15 +438,10 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
-    "@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-    },
     "@hapi/hapi": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
-      "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.3.tgz",
+      "integrity": "sha512-aqJVHVjoY3phiZsgsGjDRG15CoUNIs1azScqLZDOCZUSKYGTbzPi+K0QP+RUjUJ0m8L9dRuTZ27c8HKxG3wEhA==",
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
@@ -487,9 +474,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "@hapi/iron": {
       "version": "6.0.0",
@@ -532,11 +519,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/nigel": "4.x.x"
       }
-    },
-    "@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
     },
     "@hapi/podium": {
       "version": "4.1.1",
@@ -608,9 +590,9 @@
       }
     },
     "@hapi/validate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.2.tgz",
-      "integrity": "sha512-ojg3iE/haKh8aCZFObkOzuJ1vQ8NP+EiuibliJKe01IMstBPXQc4Xl08+8zqAL+iZSZKp1TaWdwaNSzq8HIMKA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0"
@@ -625,14 +607,32 @@
       }
     },
     "@hapi/wreck": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
-      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+      "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
         "@hapi/hoek": "9.x.x"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -2854,7 +2854,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -3337,6 +3336,14 @@
         }
       }
     },
+    "electron-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.3.tgz",
+      "integrity": "sha512-1AVMaxrHXTTMqd7EK0MGWusdqNr07Rpj8Th6bG4at0oNgIi/1LBwa9CjT/0Zy+M0k/tSJPS04nFxHj0SXDVgVw==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
+    },
     "electron-notarize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
@@ -3578,6 +3585,24 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true,
       "optional": true
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -4842,8 +4867,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
       "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "define-properties": "^1.1.3"
       }
@@ -5116,9 +5139,9 @@
       }
     },
     "human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "i18next": {
       "version": "19.4.4",
@@ -5493,23 +5516,47 @@
       }
     },
     "ipfsd-ctl": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-7.0.0.tgz",
-      "integrity": "sha512-/nsW9oe6PJhbAPMZroTurjtT/PKmS9h8cFlmK7bYMtaPXlHEN/Z6ijceSqyTnmxSUeTsQapSIduxyWEoRKeZyw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-7.2.0.tgz",
+      "integrity": "sha512-mBhrMVWz8QHQ/4P+3p0pBkeeV5R41t/6aHsu44gsvnt7JPqkDlNpjU6IpsRP9fw1OgCtsax6lz1n8BMixz9epw==",
       "requires": {
         "@hapi/boom": "^9.1.0",
         "@hapi/hapi": "^20.0.0",
         "debug": "^4.1.1",
-        "execa": "^4.0.0",
+        "execa": "^5.0.0",
         "fs-extra": "^9.0.0",
-        "ipfs-utils": "^3.0.0",
+        "ipfs-utils": "^5.0.1",
         "joi": "^17.2.1",
         "merge-options": "^3.0.1",
         "multiaddr": "^8.0.0",
         "nanoid": "^3.1.3",
+        "p-wait-for": "^3.1.0",
         "temp-write": "^4.0.0"
       },
       "dependencies": {
+        "any-signal": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.1.tgz",
+          "integrity": "sha512-kjyMTtHQsB3yZAVDZlLVucPJnmnrXhamB/rm3Td3jse5Q+16FXXolP4elWU0yLFDyrxTkjjDXtIdjSPiEznf3w==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "native-abort-controller": "0.0.3"
+          }
+        },
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5521,27 +5568,62 @@
           }
         },
         "execa": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-          "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+          "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
           "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
             "is-stream": "^2.0.0",
             "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
             "strip-final-newline": "^2.0.0"
           }
         },
         "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+          "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg=="
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "ipfs-utils": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-5.0.1.tgz",
+          "integrity": "sha512-28KZPgO4Uf5duT2ORLAYfboUp98iUshDD7yRAfbNxNAR8Dtidfn6o20rZfoXnkri2zKBVIPlJkuCPmPJB+6erg==",
           "requires": {
-            "pump": "^3.0.0"
+            "abort-controller": "^3.0.0",
+            "any-signal": "^2.1.0",
+            "buffer": "^6.0.1",
+            "electron-fetch": "^1.7.2",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^1.0.0",
+            "it-glob": "0.0.10",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "native-abort-controller": "0.0.3",
+            "native-fetch": "^2.0.0",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          },
+          "dependencies": {
+            "merge-options": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
+              "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
+              "requires": {
+                "is-plain-obj": "^2.0.0"
+              }
+            }
           }
         },
         "is-plain-obj": {
@@ -5554,25 +5636,26 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
-        "merge-options": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.2.tgz",
-          "integrity": "sha512-7TM9KD5J6TfT7Frs7PUnhA7Agkuag/vG9BdDbFtP54mrquqflOTJ30QXzlpI/ZX2cLDi6lw96eRF3ZhxkUVgKw==",
+        "iso-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.0.0.tgz",
+          "integrity": "sha512-n/MsHgKOoHcFrhsxfbM3aaSdUujoFrrZ3537p3RW80AL7axL36acCseoMwIW4tNOl0n0SnkzNyVh4bREwmHoPQ=="
+        },
+        "it-glob": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.10.tgz",
+          "integrity": "sha512-p1PR15djgPV7pxdLOW9j4WcJdla8+91rJdUU2hU2Jm68vkxpIEXK55VHBeH8Lvqh2vqLtM83t8q4BuJxue6niA==",
           "requires": {
-            "is-plain-obj": "^2.1.0"
+            "fs-extra": "^9.0.1",
+            "minimatch": "^3.0.4"
           }
         },
-        "multiaddr": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
-          "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
+        "merge-options": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+          "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
           "requires": {
-            "cids": "^1.0.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^3.0.0",
-            "uint8arrays": "^1.1.0",
-            "varint": "^5.0.0"
+            "is-plain-obj": "^2.1.0"
           }
         },
         "npm-run-path": {
@@ -5583,27 +5666,10 @@
             "path-key": "^3.0.0"
           }
         },
-        "onetime": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-          "requires": {
-            "mimic-fn": "^2.1.0"
-          }
-        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
         },
         "shebang-command": {
           "version": "2.0.0",
@@ -5617,6 +5683,11 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "signal-exit": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         }
       }
     },
@@ -6107,15 +6178,15 @@
       }
     },
     "joi": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.1.tgz",
-      "integrity": "sha512-YT3/4Ln+5YRpacdmfEfrrKh50/kkgX3LgBltjqnlMPIYiZ4hxXZuVJcxmsvxsdeHg9soZfE3qXxHC2tMpCCBOA==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
       "requires": {
-        "@hapi/address": "^4.1.0",
-        "@hapi/formula": "^2.0.0",
         "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-sha3": {
@@ -6908,6 +6979,22 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
       "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
+    "native-abort-controller": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-0.0.3.tgz",
+      "integrity": "sha512-YIxU5nWqSHG1Xbu3eOu3pdFRD882ivQpIcu6AiPVe2oSVoRbfYW63DVkZm3g1gHiMtZSvZzF6THSzTGEBYl8YA==",
+      "requires": {
+        "globalthis": "^1.0.1"
+      }
+    },
+    "native-fetch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-2.0.1.tgz",
+      "integrity": "sha512-gv4Bea+ga9QdXINurpkEqun3ap3vnB+WYoe4c8ddqUYEH7B2h6iD39RF8uVN7OwmSfMY3RDxkvBnoI4e2/vLXQ==",
+      "requires": {
+        "globalthis": "^1.0.1"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7120,8 +7207,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -7356,6 +7442,14 @@
         "fn.name": "1.x.x"
       }
     },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -7551,10 +7645,26 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "p-wait-for": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+      "requires": {
+        "p-timeout": "^3.0.0"
+      }
     },
     "package-json": {
       "version": "6.5.0",
@@ -8471,8 +8581,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "i18next-icu": "^1.3.1",
     "i18next-node-fs-backend": "^2.1.3",
     "ipfs-http-client": "47.0.1",
-    "ipfsd-ctl": "^7.0.0",
+    "ipfsd-ctl": "^7.2.0",
     "is-ipfs": "^2.0.0",
     "it-all": "^1.0.2",
     "it-concat": "^1.0.1",

--- a/src/enable-pubsub.js
+++ b/src/enable-pubsub.js
@@ -34,10 +34,8 @@ module.exports = async function () {
     try {
       if (newValue === true) {
         enable()
-        logger.info('[pubsub] enabled')
       } else {
         disable()
-        logger.info('[pubsub] disabled')
       }
 
       return true
@@ -47,9 +45,9 @@ module.exports = async function () {
       return false
     }
   }
-
   activate({ newValue: store.get(CONFIG_KEY, false) })
   createToggler(CONFIG_KEY, activate)
+  logger.info(`[pubsub] ${store.get(CONFIG_KEY, false) ? 'enabled' : 'disabled'}`)
 }
 
 module.exports.CONFIG_KEY = CONFIG_KEY

--- a/src/enable-pubsub.js
+++ b/src/enable-pubsub.js
@@ -1,0 +1,43 @@
+const createToggler = require('./utils/create-toggler')
+const logger = require('./common/logger')
+const store = require('./common/store')
+
+const CONFIG_KEY = 'pubsub'
+
+function enable () {
+  var flags = store.get('ipfsConfig.flags', [])
+  flags.push('--enable-pubsub-experiment')
+  store.set('ipfsConfig.flags', flags)
+}
+
+function disable () {
+  var flags = store.get('ipfsConfig.flags', [])
+  store.set('ipfsConfig.flags', flags.filter(item => item !== '--enable-pubsub-experiment'))
+}
+
+module.exports = async function () {
+  const activate = ({ newValue, oldValue }) => {
+    if (newValue === oldValue) return
+
+    try {
+      if (newValue === true) {
+        enable()
+        logger.info('[pubsub] enabled')
+      } else {
+        disable()
+        logger.info('[pubsub] disabled')
+      }
+
+      return true
+    } catch (err) {
+      logger.error(`[pubsub] ${err.toString()}`)
+
+      return false
+    }
+  }
+
+  activate({ newValue: store.get(CONFIG_KEY, false) })
+  createToggler(CONFIG_KEY, activate)
+}
+
+module.exports.CONFIG_KEY = CONFIG_KEY

--- a/src/enable-pubsub.js
+++ b/src/enable-pubsub.js
@@ -48,6 +48,7 @@ module.exports = async function () {
     }
   }
 
+  activate({ newValue: store.get(CONFIG_KEY, false) })
   createToggler(CONFIG_KEY, activate)
 }
 

--- a/src/enable-pubsub.js
+++ b/src/enable-pubsub.js
@@ -5,26 +5,27 @@ const { ipcMain } = require('electron')
 
 const CONFIG_KEY = 'pubsub'
 const pubsubFlag = '--enable-pubsub-experiment'
+const isEnabled = flags => flags.some(f => f === pubsubFlag)
 
 function enable () {
-  let flags = store.get('ipfsConfig.flags', [])
-  flags = flags.filter(item => item !== pubsubFlag) // avoid duplication when user has one added manually
-  flags.push(pubsubFlag)
-  applyConfig(flags)
+  const flags = store.get('ipfsConfig.flags', [])
+  if (!isEnabled(flags)) {
+    flags.push(pubsubFlag)
+    applyConfig(flags)
+  }
 }
 
 function disable () {
   let flags = store.get('ipfsConfig.flags', [])
-  flags = flags.filter(item => item !== pubsubFlag) // remove flag
-  applyConfig(flags)
+  if (isEnabled(flags)) {
+    flags = flags.filter(item => item !== pubsubFlag) // remove flag
+    applyConfig(flags)
+  }
 }
 
 function applyConfig (newFlags) {
-  const flags = store.get('ipfsConfig.flags', [])
-  if (flags.length !== newFlags.length) {
-    store.set('ipfsConfig.flags', newFlags)
-    ipcMain.emit('ipfsConfigChanged') // trigger node restart
-  }
+  store.set('ipfsConfig.flags', newFlags)
+  ipcMain.emit('ipfsConfigChanged') // trigger node restart
 }
 
 module.exports = async function () {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const setupNpmOnIpfs = require('./npm-on-ipfs')
 const setupDaemon = require('./daemon')
 const setupWebUI = require('./webui')
 const setupAutoLaunch = require('./auto-launch')
+const setupPubsub = require('./enable-pubsub')
 const setupDownloadCid = require('./download-cid')
 const setupTakeScreenshot = require('./take-screenshot')
 const setupAppMenu = require('./app-menu')
@@ -74,6 +75,7 @@ async function run () {
     await Promise.all([
       setupArgvFilesHandler(ctx),
       setupAutoLaunch(ctx),
+      setupPubsub(ctx),
       setupSecondInstance(ctx),
       // Setup global shortcuts
       setupDownloadCid(ctx),

--- a/src/tray.js
+++ b/src/tray.js
@@ -13,6 +13,7 @@ const { IS_MAC, IS_WIN, VERSION, GO_IPFS_VERSION } = require('./common/consts')
 const { CONFIG_KEY: SCREENSHOT_KEY, SHORTCUT: SCREENSHOT_SHORTCUT, takeScreenshot } = require('./take-screenshot')
 const { CONFIG_KEY: DOWNLOAD_KEY, SHORTCUT: DOWNLOAD_SHORTCUT, downloadCid } = require('./download-cid')
 const { CONFIG_KEY: AUTO_LAUNCH_KEY, isSupported: supportsLaunchAtLogin } = require('./auto-launch')
+const { CONFIG_KEY: PUBSUB_KEY } = require('./enable-pubsub')
 const { CONFIG_KEY: IPFS_PATH_KEY } = require('./ipfs-on-path')
 const { CONFIG_KEY: NPM_IPFS_KEY } = require('./npm-on-ipfs')
 const { CONFIG_KEY: AUTO_LAUNCH_WEBUI_KEY } = require('./webui')
@@ -23,7 +24,8 @@ const CONFIG_KEYS = [
   IPFS_PATH_KEY,
   NPM_IPFS_KEY,
   SCREENSHOT_KEY,
-  DOWNLOAD_KEY
+  DOWNLOAD_KEY,
+  PUBSUB_KEY
 ]
 
 function buildCheckbox (key, label) {
@@ -122,6 +124,7 @@ function buildMenu (ctx) {
         },
         buildCheckbox(AUTO_LAUNCH_KEY, 'settings.launchOnStartup'),
         buildCheckbox(AUTO_LAUNCH_WEBUI_KEY, 'settings.openWebUIAtLaunch'),
+        buildCheckbox(PUBSUB_KEY, 'settings.pubsub'),
         buildCheckbox(IPFS_PATH_KEY, 'settings.ipfsCommandLineTools'),
         buildCheckbox(SCREENSHOT_KEY, 'settings.takeScreenshotShortcut'),
         buildCheckbox(DOWNLOAD_KEY, 'settings.downloadHashShortcut'),

--- a/src/tray.js
+++ b/src/tray.js
@@ -124,7 +124,6 @@ function buildMenu (ctx) {
         },
         buildCheckbox(AUTO_LAUNCH_KEY, 'settings.launchOnStartup'),
         buildCheckbox(AUTO_LAUNCH_WEBUI_KEY, 'settings.openWebUIAtLaunch'),
-        buildCheckbox(PUBSUB_KEY, 'settings.pubsub'),
         buildCheckbox(IPFS_PATH_KEY, 'settings.ipfsCommandLineTools'),
         buildCheckbox(SCREENSHOT_KEY, 'settings.takeScreenshotShortcut'),
         buildCheckbox(DOWNLOAD_KEY, 'settings.downloadHashShortcut'),
@@ -133,6 +132,7 @@ function buildMenu (ctx) {
           label: i18n.t('settings.experiments'),
           enabled: false
         },
+        buildCheckbox(PUBSUB_KEY, 'settings.pubsub'),
         buildCheckbox(NPM_IPFS_KEY, 'settings.npmOnIpfs')
       ]
     },

--- a/test/e2e/launch.e2e.js
+++ b/test/e2e/launch.e2e.js
@@ -139,10 +139,11 @@ describe('Application launch', function () {
     expect(app.isRunning()).to.be.true()
     const { peerId } = await daemonReady(app)
     expect(peerId).to.be.equal(expectedId)
-    await app.stop()
 
     // ensure app has enabled cors checking
     config = fs.readJsonSync(configPath)
+    await app.stop()
+
     expect(config.API.HTTPHeaders['Access-Control-Allow-Origin']).to.be.deep.equal([])
   })
 


### PR DESCRIPTION
Part of https://github.com/ipfs-shipyard/ipfs-desktop/issues/1647

![Screenshot 2021-01-19 at 13 48 38](https://user-images.githubusercontent.com/1060/105062362-70319000-5a72-11eb-9fff-6468914ceb3c.png)

Adds a menu preference option to enable pubsub which adds a flag to the ipfsd-ctl options for startup.

Question: should this prompt a restart, given that the setting won't take effect until ipfs has been been restarted?

Bug: I'm getting the enabled/disabled message logged twice when clicking on the menu item, not quite sure why :
```
$ npm start

> ipfs-desktop@0.13.2 start
> cross-env NODE_ENV=development electron .

2021-01-19T16:19:06.988Z info: [meta] logs can be found on /Users/andrewnesbitt/Library/Application Support/IPFS Desktop
2021-01-19T16:19:10.560Z info: [web ui] window ready
2021-01-19T16:19:10.560Z info: [tray] starting
2021-01-19T16:19:10.607Z info: [tray] started
2021-01-19T16:19:10.608Z info: [ipfsd] start daemon STARTED
2021-01-19T16:19:10.937Z info: [daemon] removing api file
2021-01-19T16:19:11.954Z info: [ipfsd] start daemon FINISHED 1.3460042808055879s
2021-01-19T16:19:11.957Z info: [launch on startup] unavailable during development
2021-01-19T16:19:11.972Z info: [pubsub] disabled
2021-01-19T16:19:11.975Z info: [ipfs on path] no action taken
2021-01-19T16:19:17.770Z info: [pubsub] enabled
2021-01-19T16:19:17.791Z info: [pubsub] enabled
2021-01-19T16:22:36.969Z info: [pubsub] disabled
2021-01-19T16:22:37.000Z info: [pubsub] disabled
```