### PR TITLE
fix: default Open at Launch to true

### DIFF
--- a/src/webui/index.js
+++ b/src/webui/index.js
@@ -7,7 +7,6 @@ const os = require('os')
 const openExternal = require('./open-external')
 const logger = require('../common/logger')
 const store = require('../common/store')
-const { IS_MAC, IS_WIN } = require('../common/consts')
 const dock = require('../utils/dock')
 const { VERSION, ELECTRON_VERSION } = require('../common/consts')
 const createToggler = require('../utils/create-toggler')
@@ -77,11 +76,12 @@ const apiOrigin = (apiMultiaddr) => {
 
 module.exports = async function (ctx) {
   if (store.get(CONFIG_KEY, null) === null) {
-    // First time running this. If it's not macOS, nor Windows,
-    // enable opening ipfs-webui at app launch.
-    // This is the best we can do to mitigate Tray issues on Linux:
-    // https://github.com/ipfs-shipyard/ipfs-desktop/issues/1153
-    store.set(CONFIG_KEY, !IS_MAC && !IS_WIN)
+    // First time running this. Enable opening ipfs-webui at app launch.
+    // This accounts for users on OSes who may have extensions for
+    // decluttering system menus/trays, and thus have no initial "way in" to
+    // Desktop upon install:
+    // https://github.com/ipfs-shipyard/ipfs-desktop/issues/1741
+    store.set(CONFIG_KEY, true)
   }
 
   createToggler(CONFIG_KEY, async ({ newValue }) => {


### PR DESCRIPTION
Fixes #1741 by defaulting `openWebUIAtLaunch` to `true`.

This change is particularly useful for users who have extensions that declutter their system/tray which may initially hinder access to the Desktop app.