### PR TITLE
refactor: tray click events

### DIFF
--- a/src/tray.js
+++ b/src/tray.js
@@ -262,14 +262,20 @@ module.exports = function (ctx) {
     ctx.launchWebUI('/files', { focus: false })
   })
 
+  const popupMenu = (event) => {
+    // https://github.com/ipfs-shipyard/ipfs-desktop/issues/1762 ¯\_(ツ)_/¯
+    if (event && typeof event.preventDefault === 'function') event.preventDefault()
+
+    tray.popUpContextMenu()
+  }
+
   if (!IS_MAC) {
     // Show the context menu on left click on other
     // platforms than macOS.
-    tray.on('click', event => {
-      event.preventDefault()
-      tray.popUpContextMenu()
-    })
+    tray.on('click', popupMenu)
   }
+  tray.on('right-click', popupMenu)
+  tray.on('double-click', () => ctx.launchWebUI('/'))
 
   const setupMenu = () => {
     menu = buildMenu(ctx)


### PR DESCRIPTION
- avoid `TypeError: event.preventDefault is not a function`  (closes #1762)
- double-click opens webui (closes #1764)


#### TODO

- [x] linux ok
- [x] windows ok-ish 
  - tray fixed, but entire windows experience is so bad I don't know if things are broken or just slow
  - it blows my mind that 20 years later Windows platform still has janky tray icon code: it does not disappear when you kill the process, you can get duplicate "phantom"  one... :exploding_head: :exploding_head:  knowing its broken everywhere in some way or another makes me feel bit better about mess on linux (#1153) :trollface: 