### PR TITLE
chore: deprecate ipfs-on-path

### DIFF
--- a/src/tray.js
+++ b/src/tray.js
@@ -34,6 +34,7 @@ const CONFIG_KEYS = [
 
 // We show them if user enabled them before, but hide when off
 const DEPRECATED_KEYS = new Set([
+  IPFS_PATH_KEY, // brittle, buggy, way better if user does this by hand for now
   NPM_IPFS_KEY // superseded by https://github.com/forestpm/forest
 ])
 


### PR DESCRIPTION
"ipfs-on-path" opt-in feature aims to add `ipfs` binary to `PATH` on every platform. 
Unfortunately that is brittle, buggy, way better if user does this by hand for now.

We have a bunch of creative hacks that make it work most of the time, but after looking how we do it, I don't feel comfortable keeping this as a feature:
-  relies on brittle scripts which break over time and degrade user experience
-  we don't have bandwidth for maintaining this feature for all platforms
  - windows requires powershell, which a lot of users dont have on PATH (sic!)
  - linux requires polkit, not every distro uses that
    - even so, iiuc it is not even possible to make it work in sandboxed contexts like Snap or AppImage
- adding to global PATH is a security-sensitive task and I don't think a desktop app should do this

:point_right:  This PR keeps the feature enabled for existing users, but will hide menu item for new users, so it is phased out over time.  If you want `ipfs` on your `PATH`   follow https://docs.ipfs.io/install/command-line/ 

Just to illustrate, issues caused by ipfs-on-path: 
https://github.com/ipfs-shipyard/ipfs-desktop/issues/1357
https://github.com/ipfs-shipyard/ipfs-desktop/issues/1301
https://github.com/ipfs-shipyard/ipfs-desktop/issues/1761
https://github.com/ipfs-shipyard/ipfs-desktop/issues/1694
https://github.com/ipfs-shipyard/ipfs-desktop/issues/1755